### PR TITLE
Implement GSettings for Preferences Window

### DIFF
--- a/data/com.github.mclellac.NetworkMap.gschema.xml
+++ b/data/com.github.mclellac.NetworkMap.gschema.xml
@@ -1,5 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist gettext-domain="networkmap">
 	<schema id="com.github.mclellac.NetworkMap" path="/com/github/mclellac/NetworkMap/">
+    <key name="results-font" type="s">
+      <default>'Monospace 10'</default>
+      <summary>Font for the results text view</summary>
+      <description>Specifies the font name and size to be used for displaying scan results. Format is "Font Name Size", e.g., "Monospace 10".</description>
+    </key>
+
+    <key name="theme" type="s">
+      <choices>
+        <choice value='system'/>
+        <choice value='light'/>
+        <choice value='dark'/>
+      </choices>
+      <default>'system'</default>
+      <summary>Application theme preference</summary>
+      <description>Allows choosing between System, Light, or Dark theme. Requires application restart or dynamic switching logic.</description>
+    </key>
+
+    <key name="dns-servers" type="s">
+      <default>''</default>
+      <summary>Custom DNS servers for Nmap scans</summary>
+      <description>A comma-separated list of DNS servers to be used by Nmap. If empty, system DNS servers are used.</description>
+    </key>
 	</schema>
 </schemalist>

--- a/src/gtk/preferences.ui
+++ b/src/gtk/preferences.ui
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <requires lib="gtk" version="4.0"/>
+  <requires lib="adw" version="1"/>
+  <template class="NetworkMapPreferencesWindow" parent="AdwPreferencesWindow">
+    <property name="title">Preferences</property> <!-- Or use translatable string -->
+    <property name="modal">true</property>
+    <child>
+      <object class="AdwPreferencesPage">
+        <child>
+          <object class="AdwPreferencesGroup" id="appearance_group">
+            <property name="title">Appearance</property> <!-- Or use translatable string -->
+            <child>
+              <object class="AdwFontRow" id="pref_font_row">
+                <property name="title">Results Area Font</property> <!-- Or use translatable string -->
+                <!-- GSettings binding will be done in Python or could be attempted here if AdwFontRow supports it directly via use-gsetting -->
+              </object>
+            </child>
+            <child>
+              <object class="AdwComboRow" id="pref_theme_combo_row">
+                <property name="title">Application Theme</property> <!-- Or use translatable string -->
+                <property name="model">
+                  <object class="GtkStringList">
+                    <items>
+                      <item translatable="yes">System</item>
+                      <item translatable="yes">Light</item>
+                      <item translatable="yes">Dark</item>
+                    </items>
+                  </object>
+                </property>
+                <!-- GSettings binding will be done in Python -->
+              </object>
+            </child>
+          </object> <!-- End AdwPreferencesGroup appearance_group -->
+        </child>
+        <child>
+          <object class="AdwPreferencesGroup" id="scanning_group">
+            <property name="title">Scanning</property> <!-- Or use translatable string -->
+            <child>
+              <object class="AdwEntryRow" id="pref_dns_servers_entry_row">
+                <property name="title">Custom DNS Servers</property> <!-- Or use translatable string -->
+                <property name="tooltip-text">Comma-separated list of IP addresses. Leave empty to use system DNS.</property> <!-- Or use translatable string -->
+                <!-- GSettings binding will be done in Python -->
+              </object>
+            </child>
+          </object> <!-- End AdwPreferencesGroup scanning_group -->
+        </child>
+      </object> <!-- End AdwPreferencesPage -->
+    </child>
+  </template>
+</interface>

--- a/src/main.py
+++ b/src/main.py
@@ -18,6 +18,7 @@ from gi.repository import Gtk, Gio, Adw, GLib # Added GLib for GLib.Variant if n
 
 # Local application imports
 from .window import NetworkMapWindow
+from .preferences_window import NetworkMapPreferencesWindow # Import PreferencesWindow
 
 # --- Application Metadata Constants ---
 APP_ID: str = "com.github.mclellac.NetworkMap"
@@ -49,6 +50,21 @@ class NetworkMapApplication(Adw.Application):
         self.create_action("about", self._on_about_action)
         self.create_action("preferences", self._on_preferences_action)
         # self.create_action("help", self._on_help_action, ["<primary>h", "F1"]) # Example for help
+
+        self._apply_initial_theme() # Call to apply theme on startup
+
+    def _apply_initial_theme(self) -> None:
+        """Applies the saved theme preference at application startup."""
+        settings = Gio.Settings.new("com.github.mclellac.NetworkMap")
+        theme_str = settings.get_string("theme")
+        
+        style_manager = Adw.StyleManager.get_default()
+        if theme_str == "light":
+            style_manager.set_color_scheme(Adw.ColorScheme.FORCE_LIGHT)
+        elif theme_str == "dark":
+            style_manager.set_color_scheme(Adw.ColorScheme.FORCE_DARK)
+        else: # "system" or any other fallback
+            style_manager.set_color_scheme(Adw.ColorScheme.DEFAULT)
 
     def do_activate(self) -> None:
         """
@@ -101,13 +117,21 @@ class NetworkMapApplication(Adw.Application):
 
     def _on_preferences_action(self, action: Gio.SimpleAction, parameter: Optional[GLib.Variant]) -> None:
         """
-        Handles the 'preferences' action.
-        Placeholder: In a real application, this would open a preferences dialog.
+        Handles the 'preferences' action by creating and presenting the preferences window.
         """
-        print(f"Action 'app.{action.get_name()}' activated. Preferences dialog should open.")
-        # Example:
-        # prefs_window = PreferencesWindow(application=self, transient_for=self.get_active_window())
-        # prefs_window.present()
+        active_window = self.get_active_window()
+        if not active_window:
+            # This case should ideally not happen if preferences are accessed from main window.
+            # If it can, ensure the main window is created first or handle appropriately.
+            print("Error: No active window to make preferences dialog transient for.")
+            # Optionally, create and show the main window first:
+            # self.do_activate() # This might lead to unexpected behavior if called out of sequence.
+            # active_window = self.get_active_window()
+            # if not active_window: return # Still no window, abort.
+            return # Abort if no active window
+
+        prefs_window = NetworkMapPreferencesWindow(parent_window=active_window)
+        prefs_window.present()
 
 
     # def _on_help_action(self, action: Gio.SimpleAction, parameter: Optional[GLib.Variant]) -> None:

--- a/src/networkmap.gresource.xml
+++ b/src/networkmap.gresource.xml
@@ -3,5 +3,6 @@
   <gresource prefix="/com/github/mclellac/NetworkMap">
     <file preprocess="xml-stripblanks">window.ui</file>
     <file preprocess="xml-stripblanks">gtk/help-overlay.ui</file>
+    <file preprocess="xml-stripblanks">gtk/preferences.ui</file> <!-- ADD THIS LINE -->
   </gresource>
 </gresources>

--- a/src/preferences_window.py
+++ b/src/preferences_window.py
@@ -1,0 +1,85 @@
+from gi.repository import Adw, Gtk, GObject, Gio, Pango # Added Gio and Pango
+
+@Gtk.Template(resource_path="/com/github/mclellac/NetworkMap/gtk/preferences.ui")
+class NetworkMapPreferencesWindow(Adw.PreferencesWindow):
+    __gtype_name__ = "NetworkMapPreferencesWindow"
+
+    # Mappings for theme settings
+    THEME_MAP_GSETTINGS_TO_INDEX = {"system": 0, "light": 1, "dark": 2}
+    # Order must match the GtkStringList items in preferences.ui: System, Light, Dark
+    THEME_MAP_INDEX_TO_GSETTINGS = ["system", "light", "dark"]
+
+    # Template children (IDs must match those in preferences.ui)
+    pref_font_row: Adw.FontRow = Gtk.Template.Child("pref_font_row")
+    pref_theme_combo_row: Adw.ComboRow = Gtk.Template.Child("pref_theme_combo_row")
+    pref_dns_servers_entry_row: Adw.EntryRow = Gtk.Template.Child("pref_dns_servers_entry_row")
+
+    def __init__(self, parent_window: Gtk.Window):
+        super().__init__(transient_for=parent_window)
+        self.settings = Gio.Settings.new("com.github.mclellac.NetworkMap")
+        
+        # Load initial font setting
+        font_str = self.settings.get_string("results-font")
+        if font_str:  # Ensure the string is not empty
+            font_desc = Pango.FontDescription.from_string(font_str)
+            self.pref_font_row.set_font_desc(font_desc)
+            self.pref_font_row.set_use_font(True) # Ensure the row uses and displays the font
+
+        # Connect signals for preferences
+        self.pref_font_row.connect("notify::font-desc", self._on_font_changed)
+        
+        # Load initial theme setting
+        theme_str = self.settings.get_string("theme")
+        selected_theme_index = self.THEME_MAP_GSETTINGS_TO_INDEX.get(theme_str, 0) # Default to 'system'
+        self.pref_theme_combo_row.set_selected(selected_theme_index)
+        self.pref_theme_combo_row.connect("notify::selected", self._on_theme_changed)
+
+        # Bind DNS servers entry row using Gio.Settings.bind for two-way binding
+        self.settings.bind(
+            "dns-servers",
+            self.pref_dns_servers_entry_row,
+            "text", # Property of Adw.EntryRow to bind
+            Gio.SettingsBindFlags.DEFAULT
+        )
+        
+        # print("NetworkMapPreferencesWindow initialized")
+
+    def _on_font_changed(self, font_row: Adw.FontRow, pspec: GObject.ParamSpec) -> None:
+        """Handles changes to the results-font setting."""
+        font_desc = font_row.get_font_desc()
+        if font_desc: # font_desc can be None if 'use-font' is false and no font is set.
+            font_str = font_desc.to_string()
+            self.settings.set_string("results-font", font_str)
+        # If font_desc is None, it implies the user might have cleared the font
+        # or 'use-font' was turned off. Depending on desired behavior,
+        # one might set a default or clear the GSettings key.
+        # For Adw.FontRow, if use_font is True, it usually ensures a valid font_desc.
+
+    def _on_theme_changed(self, combo_row: Adw.ComboRow, pspec: GObject.ParamSpec) -> None:
+        """Handles changes to the theme setting."""
+        selected_index = combo_row.get_selected()
+        if 0 <= selected_index < len(self.THEME_MAP_INDEX_TO_GSETTINGS):
+            theme_str = self.THEME_MAP_INDEX_TO_GSETTINGS[selected_index]
+            self.settings.set_string("theme", theme_str)
+
+            # Apply the theme immediately
+            style_manager = Adw.StyleManager.get_default()
+            if theme_str == "light":
+                style_manager.set_color_scheme(Adw.ColorScheme.FORCE_LIGHT)
+            elif theme_str == "dark":
+                style_manager.set_color_scheme(Adw.ColorScheme.FORCE_DARK)
+            else:  # "system" or any other fallback
+                style_manager.set_color_scheme(Adw.ColorScheme.DEFAULT)
+        # else: The ComboRow model should prevent out-of-bounds indices if items are fixed.
+
+# Example of how this might be instantiated (for testing, not part of this file yet):
+# if __name__ == '__main__':
+#     # This is placeholder code for direct testing if possible,
+#     # normally it's launched by the main app.
+#     app = Adw.Application(application_id="com.github.mclellac.NetworkMap.PrefsTest")
+#     def on_activate(application):
+#         win = NetworkMapPreferencesWindow(parent_window=None) # Pass a dummy parent or handle None
+#         win.set_application(application)
+#         win.present()
+#     app.connect("activate", on_activate)
+#     app.run([])


### PR DESCRIPTION
This commit adds GSettings integration for the new preferences window, allowing settings to be loaded and saved. It also includes the initial implementation for applying the selected theme.

Key changes:

- preferences_window.py (`src/preferences_window.py`):
    - Initialized `Gio.Settings` for "com.github.mclellac.NetworkMap".
    - Implemented GSettings binding for `pref_font_row` (results font):
        - Loads font string from GSettings, converts to Pango.FontDescription, and sets it on the Adw.FontRow.
        - Saves changes from Adw.FontRow back to GSettings via `_on_font_changed`.
    - Implemented GSettings binding for `pref_theme_combo_row` (application theme): - Loads theme string, maps to Adw.ComboRow index, and sets selection. - Saves changes from Adw.ComboRow back to GSettings via `_on_theme_changed`. - Immediately applies theme change using `Adw.StyleManager`.
    - Implemented GSettings binding for `pref_dns_servers_entry_row` (DNS servers):
        - Uses `Gio.Settings.bind()` for direct two-way binding with the "text" property.

- main.py (`src/main.py`):
    - Added `_apply_initial_theme` method to `NetworkMapApplication` to load and apply the saved theme on application startup.
    - Updated `_on_preferences_action` to launch the `NetworkMapPreferencesWindow`.

- GSettings Schema (`data/com.github.mclellac.NetworkMap.gschema.xml`):
    - Contains keys for "results-font", "theme", and "dns-servers".

- Preferences UI (`src/gtk/preferences.ui`):
    - Defines the UI structure for the preferences window.