### PR TITLE
I've simplified `src/preferences_window.py` to just a print statement…

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -94,6 +94,7 @@ class NetworkMapApplication(Adw.Application):
             copyright=COPYRIGHT_INFO,
             website=PRIMARY_WEBSITE,
             issue_url=ISSUE_TRACKER_URL,
+            transient_for=self.get_active_window(), # Set property here
             # Translators: Replace this string with your names, one name per line.
             # translator_credits=_("translator-credits"), # This line uses gettext
         )
@@ -112,7 +113,7 @@ class NetworkMapApplication(Adw.Application):
             # No action needed here; translator_credits will remain unset.
             pass
 
-        about_dialog.set_transient_for(self.get_active_window())
+        # about_dialog.set_transient_for(self.get_active_window()) # Removed this line
         about_dialog.present()
 
     def _on_preferences_action(self, action: Gio.SimpleAction, parameter: Optional[GLib.Variant]) -> None:

--- a/src/preferences_window.py
+++ b/src/preferences_window.py
@@ -1,38 +1,8 @@
-from gi.repository import Adw, Gtk, GObject, Gio, Pango # Keep imports for now
+# Minimal src/preferences_window.py for debugging
+print("Attempting to import preferences_window.py (ultra-simplified)")
 
-# @Gtk.Template(resource_path="/com/github/mclellac/NetworkMap/gtk/preferences.ui") # COMMENTED OUT
-class NetworkMapPreferencesWindow(Adw.PreferencesWindow):
-    # __gtype_name__ = "NetworkMapPreferencesWindow" # COMMENTED OUT
-
-    # THEME_MAP_GSETTINGS_TO_INDEX = {"system": 0, "light": 1, "dark": 2} # Can remain
-    # THEME_MAP_INDEX_TO_GSETTINGS = ["system", "light", "dark"] # Can remain
-
-    # Template children - COMMENTED OUT
-    # pref_font_row: Adw.FontRow = Gtk.Template.Child("pref_font_row")
-    # pref_theme_combo_row: Adw.ComboRow = Gtk.Template.Child("pref_theme_combo_row")
-    # pref_dns_servers_entry_row: Adw.EntryRow = Gtk.Template.Child("pref_dns_servers_entry_row")
-
-    def __init__(self, parent_window: Gtk.Window):
-        super().__init__(transient_for=parent_window)
-        # All GSettings, initial value loading, signal connections, etc. should still be commented out
-        # from the previous simplification step.
-        print("NetworkMapPreferencesWindow initialized (hyper-simplified, no template)")
-
-    # Signal handlers (_on_font_changed, _on_theme_changed) should still be commented out.
-    # def _on_font_changed(self, font_row: Adw.FontRow, pspec: GObject.ParamSpec) -> None:
-    #     pass
-
-    # def _on_theme_changed(self, combo_row: Adw.ComboRow, pspec: GObject.ParamSpec) -> None:
-    #     pass
-
-# Example of how this might be instantiated (for testing, not part of this file yet):
-# if __name__ == '__main__':
-#     # This is placeholder code for direct testing if possible,
-#     # normally it's launched by the main app.
-#     app = Adw.Application(application_id="com.github.mclellac.NetworkMap.PrefsTest")
-#     def on_activate(application):
-#         win = NetworkMapPreferencesWindow(parent_window=None) # Pass a dummy parent or handle None
-#         win.set_application(application)
-#         win.present()
-#     app.connect("activate", on_activate)
-#     app.run([])
+# For this initial test, we are not even defining the class
+# NetworkMapPreferencesWindow to see if the file itself can be processed
+# by Python's import system when imported by src/main.py.
+# If this step works, src/main.py will fail later with an ImportError
+# because NetworkMapPreferencesWindow is not defined here, which is expected.


### PR DESCRIPTION
…. I'm doing this to debug the "Could not import main module" error that happens when `main.py` tries to import `NetworkMapPreferencesWindow` from this file.

I expect this change to cause an `ImportError: cannot import name NetworkMapPreferencesWindow` if Python's import system processes the file. If the "Could not import main module" error continues, the problem is more fundamental.