### PR TITLE
I've fixed the preferences UI and updated the window logic.

### DIFF
--- a/src/gtk/preferences.ui
+++ b/src/gtk/preferences.ui
@@ -11,9 +11,17 @@
           <object class="AdwPreferencesGroup" id="appearance_group">
             <property name="title">Appearance</property> <!-- Or use translatable string -->
             <child>
-              <object class="AdwFontRow" id="pref_font_row">
-                <property name="title">Results Area Font</property> <!-- Or use translatable string -->
-                <!-- GSettings binding will be done in Python or could be attempted here if AdwFontRow supports it directly via use-gsetting -->
+              <object class="AdwActionRow" id="pref_font_action_row"> <!-- ID changed -->
+                <property name="title">Results Area Font</property>
+                <child>
+                  <object class="GtkFontButton" id="pref_font_button"> <!-- New ID for the button -->
+                    <property name="halign">start</property>
+                    <property name="valign">center</property>
+                    <property name="use-font">true</property> <!-- Make button display current font -->
+                    <property name="use-size">true</property> <!-- Make button display current size -->
+                    <!-- Python will handle getting/setting the font and GSettings -->
+                  </object>
+                </child>
               </object>
             </child>
             <child>

--- a/src/preferences_window.py
+++ b/src/preferences_window.py
@@ -1,26 +1,74 @@
-from gi.repository import Adw, Gtk, GObject, Gio, Pango # Keep imports
+from gi.repository import Adw, Gtk, GObject, Gio, Pango
 
-# @Gtk.Template(resource_path="/com/github/mclellac/NetworkMap/gtk/preferences.ui") # COMMENTED OUT
+@Gtk.Template(resource_path="/com/github/mclellac/NetworkMap/gtk/preferences.ui")
 class NetworkMapPreferencesWindow(Adw.PreferencesWindow):
-    # __gtype_name__ = "NetworkMapPreferencesWindow" # COMMENTED OUT
+    __gtype_name__ = "NetworkMapPreferencesWindow"
 
-    # THEME_MAP_GSETTINGS_TO_INDEX = {"system": 0, "light": 1, "dark": 2} # Can remain
-    # THEME_MAP_INDEX_TO_GSETTINGS = ["system", "light", "dark"] # Can remain
+    # Mappings for theme settings
+    THEME_MAP_GSETTINGS_TO_INDEX = {"system": 0, "light": 1, "dark": 2}
+    # Order must match the GtkStringList items in preferences.ui: System, Light, Dark
+    THEME_MAP_INDEX_TO_GSETTINGS = ["system", "light", "dark"]
 
-    # Template children - COMMENTED OUT
-    # pref_font_row: Adw.FontRow = Gtk.Template.Child("pref_font_row")
-    # pref_theme_combo_row: Adw.ComboRow = Gtk.Template.Child("pref_theme_combo_row")
-    # pref_dns_servers_entry_row: Adw.EntryRow = Gtk.Template.Child("pref_dns_servers_entry_row")
+    # Template children (IDs must match those in preferences.ui)
+    # pref_font_row: Adw.FontRow = Gtk.Template.Child("pref_font_row") # Commented out/Removed
+    pref_font_button: Gtk.FontButton = Gtk.Template.Child("pref_font_button") # Added
+    pref_theme_combo_row: Adw.ComboRow = Gtk.Template.Child("pref_theme_combo_row")
+    pref_dns_servers_entry_row: Adw.EntryRow = Gtk.Template.Child("pref_dns_servers_entry_row")
 
     def __init__(self, parent_window: Gtk.Window):
         super().__init__(transient_for=parent_window)
-        # All GSettings, initial value loading, signal connections, etc. should remain commented out
-        # from the previous full simplification step.
-        print("NetworkMapPreferencesWindow initialized (hyper-simplified, no template)")
+        self.settings = Gio.Settings.new("com.github.mclellac.NetworkMap")
+        
+        # Load initial font setting
+        font_str = self.settings.get_string("results-font")
+        if font_str:  # Ensure the string is not empty
+            font_desc = Pango.FontDescription.from_string(font_str)
+            self.pref_font_button.set_font_desc(font_desc) # Changed to pref_font_button
+            # self.pref_font_row.set_use_font(True) # Removed, GtkFontButton handles this
 
-    # Signal handlers (_on_font_changed, _on_theme_changed) should remain commented out.
-    # def _on_font_changed(self, font_row: Adw.FontRow, pspec: GObject.ParamSpec) -> None:
-    #     pass
+        # Connect signals for preferences
+        self.pref_font_button.connect("font-set", self._on_font_changed) # Changed signal and source
+        
+        # Load initial theme setting
+        theme_str = self.settings.get_string("theme")
+        selected_theme_index = self.THEME_MAP_GSETTINGS_TO_INDEX.get(theme_str, 0) # Default to 'system'
+        self.pref_theme_combo_row.set_selected(selected_theme_index)
+        self.pref_theme_combo_row.connect("notify::selected", self._on_theme_changed)
 
-    # def _on_theme_changed(self, combo_row: Adw.ComboRow, pspec: GObject.ParamSpec) -> None:
-    #     pass
+        # Bind DNS servers entry row using Gio.Settings.bind for two-way binding
+        self.settings.bind(
+            "dns-servers",
+            self.pref_dns_servers_entry_row,
+            "text", # Property of Adw.EntryRow to bind
+            Gio.SettingsBindFlags.DEFAULT
+        )
+        
+        # print("NetworkMapPreferencesWindow initialized") # For debugging if needed
+
+    def _on_font_changed(self, font_button: Gtk.FontButton) -> None: # Signature changed
+        """Handles changes to the results-font setting."""
+        font_desc = font_button.get_font_desc() # Get from GtkFontButton argument
+        if font_desc: 
+            font_str = font_desc.to_string()
+            self.settings.set_string("results-font", font_str)
+        # If font_desc is None, it implies the user might have cleared the font
+        # or 'use-font' was turned off. Depending on desired behavior,
+        # one might set a default or clear the GSettings key.
+        # For Adw.FontRow, if use_font is True, it usually ensures a valid font_desc.
+
+    def _on_theme_changed(self, combo_row: Adw.ComboRow, pspec: GObject.ParamSpec) -> None:
+        """Handles changes to the theme setting."""
+        selected_index = combo_row.get_selected()
+        if 0 <= selected_index < len(self.THEME_MAP_INDEX_TO_GSETTINGS):
+            theme_str = self.THEME_MAP_INDEX_TO_GSETTINGS[selected_index]
+            self.settings.set_string("theme", theme_str)
+
+            # Apply the theme immediately
+            style_manager = Adw.StyleManager.get_default()
+            if theme_str == "light":
+                style_manager.set_color_scheme(Adw.ColorScheme.FORCE_LIGHT)
+            elif theme_str == "dark":
+                style_manager.set_color_scheme(Adw.ColorScheme.FORCE_DARK)
+            else:  # "system" or any other fallback
+                style_manager.set_color_scheme(Adw.ColorScheme.DEFAULT)
+        # else: The ComboRow model should prevent out-of-bounds indices if items are fixed.


### PR DESCRIPTION
- I replaced `AdwFontRow` with `AdwActionRow` containing a `GtkFontButton` in `gtk/preferences.ui`. This will ensure UI validity and fix issues reported by Cambalache.
- I adjusted `preferences_window.py` to reflect this UI change:
    - Updated `Gtk.Template.Child` declaration to use `pref_font_button` (`Gtk.FontButton`).
    - Modified font loading in `__init__` to use `pref_font_button.set_font_desc()`.
    - Changed signal connection from `notify::font-desc` to `font-set` for `pref_font_button`.
    - Adapted `_on_font_changed` handler for `Gtk.FontButton`.
- I've ensured `preferences_window.py` is fully functional with all `Gtk.Template` features, GSettings bindings (font, theme, DNS), and signal handlers active, reverting any previous debugging simplifications.

This aims to resolve the "Could not import main module" error by providing a valid UI template and correct corresponding Python code.