### PR TITLE
Fix: Remove outdated comments from meson.build files

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -1,5 +1,5 @@
 pkgdatadir = get_option('prefix') / get_option('datadir') / meson.project_name()
-moduledir = pkgdatadir # Changed line
+moduledir = pkgdatadir
 gnome = import('gnome')
 
 gnome.compile_resources('networkmap',
@@ -31,8 +31,8 @@ networkmap_sources = [
   'main.py',
   'window.py',
   'nmap_scanner.py',
-  'preferences_window.py', # Added preferences_window.py
-  'networkmap/utils.py', # Added utils.py
+  'preferences_window.py',
+  'networkmap/utils.py',
 ]
 
 install_data(networkmap_sources, install_dir: moduledir / 'networkmap')


### PR DESCRIPTION
Removes a few comments from `src/meson.build` that were irrelevant or outdated after previous refactoring, such as comments noting the addition of files to the source list. This addresses your feedback regarding comment cleanup.