### PR TITLE
Feat: Enhance Preferences and Main Window UI/UX

### DIFF
--- a/data/com.github.mclellac.NetworkMap.gschema.xml
+++ b/data/com.github.mclellac.NetworkMap.gschema.xml
@@ -23,5 +23,11 @@
       <summary>Custom DNS servers for Nmap scans</summary>
       <description>A comma-separated list of DNS servers to be used by Nmap. If empty, system DNS servers are used.</description>
     </key>
+
+    <key name="default-nmap-arguments" type="s">
+      <default>''</default>
+      <summary>Default arguments for Nmap scans</summary>
+      <description>These arguments are automatically prepended to every Nmap scan initiated through the application. Arguments specified in the main window's 'Additional Arguments' field can override or supplement these defaults.</description>
+    </key>
 	</schema>
 </schemalist>

--- a/src/gtk/preferences.ui
+++ b/src/gtk/preferences.ui
@@ -17,6 +17,7 @@
               <object class="AdwActionRow" id="pref_font_action_row">
                 <!-- ID changed -->
                 <property name="title">Results Area Font</property>
+                <property name="subtitle">Select the font for the Nmap results text view.</property>
                 <child>
                   <object class="GtkFontButton" id="pref_font_button">
                     <!-- New ID for the button -->
@@ -42,6 +43,7 @@
                   </object>
                 </property>
                 <property name="title">Application Theme</property>
+                <property name="subtitle">Choose the application-wide color scheme.</property>
               </object>
             </child>
           </object>
@@ -52,8 +54,15 @@
             <child>
               <object class="AdwEntryRow" id="pref_dns_servers_entry_row">
                 <property name="title">Custom DNS Servers</property>
+                <property name="subtitle">Leave empty to use system DNS. Separate multiple servers with commas.</property>
                 <!-- Or use translatable string -->
                 <property name="tooltip-text">Comma-separated list of IP addresses. Leave empty to use system DNS.</property>
+              </object>
+            </child>
+            <child>
+              <object class="AdwEntryRow" id="pref_default_nmap_args_entry_row">
+                <property name="title">Default Nmap Arguments</property>
+                <property name="subtitle">These arguments are prepended to every scan. User-provided arguments can override them.</property>
               </object>
             </child>
           </object>

--- a/src/preferences_window.py
+++ b/src/preferences_window.py
@@ -20,6 +20,7 @@ class NetworkMapPreferencesWindow(Adw.PreferencesWindow):
     pref_font_button: Gtk.FontButton = Gtk.Template.Child("pref_font_button")
     pref_theme_combo_row: Adw.ComboRow = Gtk.Template.Child("pref_theme_combo_row")
     pref_dns_servers_entry_row: Adw.EntryRow = Gtk.Template.Child("pref_dns_servers_entry_row")
+    pref_default_nmap_args_entry_row: Adw.EntryRow = Gtk.Template.Child() # Added new child
 
     def __init__(self, parent_window: Gtk.Window):
         """
@@ -50,6 +51,14 @@ class NetworkMapPreferencesWindow(Adw.PreferencesWindow):
         self.settings.bind(
             "dns-servers",
             self.pref_dns_servers_entry_row,
+            "text",
+            Gio.SettingsBindFlags.DEFAULT
+        )
+
+        # Bind Default Nmap Arguments entry row
+        self.settings.bind(
+            "default-nmap-arguments",
+            self.pref_default_nmap_args_entry_row,
             "text",
             Gio.SettingsBindFlags.DEFAULT
         )

--- a/src/window.py
+++ b/src/window.py
@@ -146,6 +146,9 @@ class NetworkMapWindow(Adw.ApplicationWindow):
         Worker function to perform the Nmap scan.
         This method is run in a separate thread.
         """
+        settings = Gio.Settings.new("com.github.mclellac.NetworkMap")
+        default_args_from_settings: str = settings.get_string("default-nmap-arguments")
+
         error_type: Optional[str] = None
         error_message: Optional[str] = None
         hosts_data: Optional[List[Dict[str, Any]]] = None
@@ -159,6 +162,7 @@ class NetworkMapWindow(Adw.ApplicationWindow):
                 do_os_fingerprint,
                 additional_args_str,
                 self.selected_nse_script,
+                default_args_str=default_args_from_settings, # Pass fetched default args
             )
             if scan_message and not hosts_data:
                 error_type = "ScanMessage" # Indicates message from nmap_scanner, not an exception

--- a/src/window.ui
+++ b/src/window.ui
@@ -53,15 +53,20 @@
                           </object>
                         </child>
                         <child>
-                          <object class="AdwEntryRow" id="arguments_entry_row">
-                            <property name="show-apply-button">True</property>
-                            <property name="title">additional arguments</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="AdwComboRow" id="nse_script_combo_row">
-                            <property name="subtitle">Include exectution of NSE script</property>
-                            <property name="title">NSE Script</property>
+                          <object class="AdwExpanderRow">
+                            <property name="title">Advanced Options</property>
+                            <property name="expanded">False</property>
+                            <child>
+                              <object class="AdwEntryRow" id="arguments_entry_row">
+                                <property name="title">Additional Arguments</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="AdwComboRow" id="nse_script_combo_row">
+                                <property name="subtitle">Include execution of NSE script</property>
+                                <property name="title">NSE Script</property>
+                              </object>
+                            </child>
                           </object>
                         </child>
                       </object>


### PR DESCRIPTION
This commit introduces several UI/UX improvements based on GNOME HIG principles and Libadwaita patterns:

**Preferences Window:**
- I added descriptive subtitles to all existing preference rows (Font, Theme, DNS Servers) for better clarity.
- I introduced a new preference: "Default Nmap Arguments".
    - You can now specify a string of Nmap arguments that will be automatically prepended to every scan.
    - This setting is stored via GSettings (`default-nmap-arguments`).
    - The UI includes an `AdwEntryRow` for this in the "Scanning" group.

**Main Window UI:**
- Scan controls for "Additional Arguments" and "NSE Script" are now grouped under an `Adw.ExpanderRow` titled "Advanced Options". This simplifies the default UI by hiding less frequently used options.
- I removed an unnecessary "apply" button from the "Additional Arguments" entry row.
- I standardized title casing for UI elements.
- I fixed a minor typo in a subtitle.

**Nmap Scanner Logic:**
- I updated `NmapScanner` to accept and process the new "Default Nmap Arguments" from settings.
- Default arguments are prepended to arguments you enter in the main UI's "Additional Arguments" field, allowing your specific arguments to override defaults if necessary.
- I updated relevant docstrings in `NmapScanner` to reflect these changes.