### PR TITLE
Fix: Correct Meson Python install and aggressively remove comments

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -7,7 +7,7 @@ actions, and window management. It also contains the `main` function
 which serves as the entry point for the application.
 """
 import sys
-from typing import Callable, List, Optional # Removed Any as GLib.Variant is used
+from typing import Callable, List, Optional
 
 import gi
 
@@ -16,20 +16,17 @@ gi.require_version("Adw", "1")
 
 from gi.repository import Gtk, Gio, Adw, GLib
 
-# Local application imports
 from .window import NetworkMapWindow
 from .preferences_window import NetworkMapPreferencesWindow
-from .utils import apply_theme # Updated import
+from .utils import apply_theme
 
-# --- Application Metadata Constants ---
 APP_ID: str = "com.github.mclellac.NetworkMap"
 APP_NAME: str = "Network Map"
-APP_VERSION: str = "0.1.0" # Keep this in sync with Meson build version if possible
+APP_VERSION: str = "0.1.0"
 DEVELOPER_NAME: str = "Carey McLelland"
-COPYRIGHT_INFO: str = f"© 2024-2025 {DEVELOPER_NAME}" # Consider dynamic year for long-term projects
-PRIMARY_WEBSITE: str = "https://github.com/mclellac/networkmap" # Placeholder
-ISSUE_TRACKER_URL: str = "https://github.com/mclellac/networkmap/issues" # Placeholder
-# --- End Application Metadata Constants ---
+COPYRIGHT_INFO: str = f"© 2024-2025 {DEVELOPER_NAME}"
+PRIMARY_WEBSITE: str = "https://github.com/mclellac/networkmap"
+ISSUE_TRACKER_URL: str = "https://github.com/mclellac/networkmap/issues"
 
 
 class NetworkMapApplication(Adw.Application):
@@ -42,30 +39,27 @@ class NetworkMapApplication(Adw.Application):
         """Initializes the NetworkMapApplication."""
         super().__init__(
             application_id=APP_ID,
-            flags=Gio.ApplicationFlags.FLAGS_NONE, # FLAGS_NONE is often preferred for GUI apps
+            flags=Gio.ApplicationFlags.FLAGS_NONE,
         )
-        # Set application name for proper desktop integration (e.g., .desktop file)
         GLib.set_application_name(APP_NAME)
 
         self.create_action("quit", self._on_quit_action, ["<primary>q"])
         self.create_action("about", self._on_about_action)
         self.create_action("preferences", self._on_preferences_action)
-        # self.create_action("help", self._on_help_action, ["<primary>h", "F1"]) # Example placeholder for help
 
         self._apply_initial_theme()
 
     def _apply_initial_theme(self) -> None:
         """Applies the saved theme preference at application startup."""
-        settings = Gio.Settings.new(APP_ID) # Use APP_ID for consistency
+        settings = Gio.Settings.new(APP_ID)
         theme_str = settings.get_string("theme")
-        apply_theme(theme_str) # Use the new utility function
+        apply_theme(theme_str)
 
     def do_activate(self) -> None:
         """
         Called when the application is activated.
         Presents the main application window, creating it if necessary.
         """
-        # active_window is a Gtk.Application property
         win: Optional[NetworkMapWindow] = self.get_active_window()
         if not win:
             win = NetworkMapWindow(application=self)
@@ -79,7 +73,7 @@ class NetworkMapApplication(Adw.Application):
         """Handles the 'about' action by showing the application's About dialog."""
         about_dialog = Adw.AboutDialog(
             application_name=APP_NAME,
-            application_icon=APP_ID,  # Icon name often matches app ID
+            application_icon=APP_ID,
             developer_name=DEVELOPER_NAME,
             version=APP_VERSION,
             developers=[DEVELOPER_NAME],
@@ -87,21 +81,14 @@ class NetworkMapApplication(Adw.Application):
             website=PRIMARY_WEBSITE,
             issue_url=ISSUE_TRACKER_URL,
             transient_for=self.get_active_window(),
-            # Translators: Replace this string with your names, one name per line.
-            # translator_credits=_("translator-credits"), # This uses gettext
         )
         
-        # Safely attempt to set translator_credits if gettext is available
         try:
-            # The `_` function is provided by gettext.
-            # We check if it's callable to avoid errors if gettext isn't initialized.
-            if callable(_):  # type: ignore[name-defined]
-                # type: ignore is used because `_` is not defined in this file directly.
-                translator_credits = _("translator-credits") # type: ignore[name-defined]
-                if translator_credits != "translator-credits": # Only set if translated
+            if callable(_): 
+                translator_credits = _("translator-credits") 
+                if translator_credits != "translator-credits": 
                     about_dialog.set_translator_credits(translator_credits)
         except NameError:
-            # `_` is not defined. This is expected if gettext is not initialized.
             pass
 
         about_dialog.present()
@@ -110,26 +97,11 @@ class NetworkMapApplication(Adw.Application):
         """Handles the 'preferences' action by creating and presenting the preferences window."""
         active_window = self.get_active_window()
         if not active_window:
-            # This case should ideally not happen if preferences are accessed from an active main window.
-            # If it can, ensure the main window is created first or handle appropriately.
             print(f"Warning: Action 'app.{action.get_name()}' called without an active window.")
             return
 
         prefs_window = NetworkMapPreferencesWindow(parent_window=active_window)
         prefs_window.present()
-
-
-    # def _on_help_action(self, action: Gio.SimpleAction, parameter: Optional[GLib.Variant]) -> None:
-    #     """Handles the 'help' action, e.g., by showing a help window or documentation."""
-    #     print(f"Action 'app.{action.get_name()}' activated. Help should be shown.")
-    #     # Typically, you might open a Gtk.ShortcutsWindow or an Adw.HelpOverlay here,
-    #     # or launch an external help document.
-    #     active_window = self.get_active_window()
-    #     if active_window and isinstance(active_window, NetworkMapWindow):
-    #         # Assuming NetworkMapWindow has a method to show help, like a help overlay.
-    #         # active_window.show_help_overlay_action()
-    #         pass
-
 
     def create_action(
         self, name: str, callback: Callable[[Gio.SimpleAction, Optional[GLib.Variant]], None],
@@ -164,7 +136,5 @@ def main(argv: Optional[List[str]] = None) -> int:
     app = NetworkMapApplication()
     return app.run(processed_argv)
 
-# Standard boilerplate to run main() if the script is executed directly.
-# This is less relevant if using `networkmap.in` or Meson for execution, but good practice.
 if __name__ == "__main__":
     sys.exit(main(sys.argv))

--- a/src/meson.build
+++ b/src/meson.build
@@ -12,7 +12,8 @@ gnome.compile_resources('networkmap',
 python = import('python')
 
 conf = configuration_data()
-conf.set('PYTHON', python.find_installation('python3').full_path())
+py_installation = python.find_installation('python3', required: true) # Added required: true for robustness
+conf.set('PYTHON', py_installation.full_path())
 conf.set('VERSION', meson.project_version())
 conf.set('localedir', get_option('prefix') / get_option('localedir'))
 conf.set('pkgdatadir', pkgdatadir)
@@ -35,7 +36,7 @@ networkmap_sources = [
   'utils.py', # Updated path
 ]
 
-python.install_sources(
+py_installation.install_sources(
   networkmap_sources,
   subdir: 'networkmap'
 )

--- a/src/preferences_window.py
+++ b/src/preferences_window.py
@@ -1,7 +1,6 @@
 from gi.repository import Adw, Gtk, GObject, Gio, Pango
 
-# Local application imports
-from .utils import apply_theme # Updated import
+from .utils import apply_theme
 
 @Gtk.Template(resource_path="/com/github/mclellac/NetworkMap/gtk/preferences.ui")
 class NetworkMapPreferencesWindow(Adw.PreferencesWindow):
@@ -11,16 +10,13 @@ class NetworkMapPreferencesWindow(Adw.PreferencesWindow):
     """
     __gtype_name__ = "NetworkMapPreferencesWindow"
 
-    # Mappings for theme settings
-    # Order must match the GtkStringList items in preferences.ui: System, Light, Dark
     THEME_MAP_GSETTINGS_TO_INDEX = {"system": 0, "light": 1, "dark": 2}
     THEME_MAP_INDEX_TO_GSETTINGS = ["system", "light", "dark"]
 
-    # Template children (IDs must match those in preferences.ui)
     pref_font_button: Gtk.FontButton = Gtk.Template.Child("pref_font_button")
     pref_theme_combo_row: Adw.ComboRow = Gtk.Template.Child("pref_theme_combo_row")
     pref_dns_servers_entry_row: Adw.EntryRow = Gtk.Template.Child("pref_dns_servers_entry_row")
-    pref_default_nmap_args_entry_row: Adw.EntryRow = Gtk.Template.Child() # Added new child
+    pref_default_nmap_args_entry_row: Adw.EntryRow = Gtk.Template.Child()
 
     def __init__(self, parent_window: Gtk.Window):
         """
@@ -32,22 +28,18 @@ class NetworkMapPreferencesWindow(Adw.PreferencesWindow):
         super().__init__(transient_for=parent_window)
         self.settings = Gio.Settings.new("com.github.mclellac.NetworkMap")
         
-        # Load initial font setting
         font_str = self.settings.get_string("results-font")
         if font_str:
             font_desc = Pango.FontDescription.from_string(font_str)
             self.pref_font_button.set_font_desc(font_desc)
 
-        # Connect signals for preferences
         self.pref_font_button.connect("font-set", self._on_font_changed)
         
-        # Load initial theme setting
         theme_str = self.settings.get_string("theme")
-        selected_theme_index = self.THEME_MAP_GSETTINGS_TO_INDEX.get(theme_str, 0) # Default to index 0 ('system')
+        selected_theme_index = self.THEME_MAP_GSETTINGS_TO_INDEX.get(theme_str, 0)
         self.pref_theme_combo_row.set_selected(selected_theme_index)
         self.pref_theme_combo_row.connect("notify::selected", self._on_theme_changed)
 
-        # Bind DNS servers entry row using Gio.Settings.bind for two-way binding
         self.settings.bind(
             "dns-servers",
             self.pref_dns_servers_entry_row,
@@ -55,7 +47,6 @@ class NetworkMapPreferencesWindow(Adw.PreferencesWindow):
             Gio.SettingsBindFlags.DEFAULT
         )
 
-        # Bind Default Nmap Arguments entry row
         self.settings.bind(
             "default-nmap-arguments",
             self.pref_default_nmap_args_entry_row,
@@ -72,10 +63,6 @@ class NetworkMapPreferencesWindow(Adw.PreferencesWindow):
         if font_desc: 
             font_str = font_desc.to_string()
             self.settings.set_string("results-font", font_str)
-        # If font_desc is None, it implies the user might have cleared the font.
-        # Adw.FontRow handles this by having `use-font` property. Gtk.FontButton
-        # always has a font description when "font-set" is emitted.
-        # If the button allowed clearing, we might need to handle `font_desc` being None.
 
     def _on_theme_changed(self, combo_row: Adw.ComboRow, pspec: GObject.ParamSpec) -> None:
         """
@@ -86,5 +73,4 @@ class NetworkMapPreferencesWindow(Adw.PreferencesWindow):
         if 0 <= selected_index < len(self.THEME_MAP_INDEX_TO_GSETTINGS):
             theme_str = self.THEME_MAP_INDEX_TO_GSETTINGS[selected_index]
             self.settings.set_string("theme", theme_str)
-            apply_theme(theme_str) # Use the new utility function
-        # The Adw.ComboRow model should prevent out-of-bounds indices if its items are fixed.
+            apply_theme(theme_str)

--- a/src/utils.py
+++ b/src/utils.py
@@ -22,7 +22,6 @@ def discover_nse_scripts() -> List[str]:
         Returns an empty list if the directory is not accessible or an error occurs.
     """
     script_names: List[str] = []
-    # Standard Nmap script path on most Linux systems.
     default_path = "/usr/share/nmap/scripts/"
 
     if not os.path.isdir(default_path) or not os.access(default_path, os.R_OK):
@@ -36,7 +35,7 @@ def discover_nse_scripts() -> List[str]:
             if item_name.endswith(".nse"):
                 full_item_path = os.path.join(default_path, item_name)
                 if os.path.isfile(full_item_path):
-                    script_names.append(item_name[:-4]) # Remove .nse extension
+                    script_names.append(item_name[:-4])
         
         script_names.sort()
     except OSError as e:

--- a/src/window.py
+++ b/src/window.py
@@ -1,18 +1,16 @@
 import threading
-# import os # No longer needed here
 from typing import Optional, List, Dict, Any, Tuple
 
-from gi.repository import Adw, Gtk, GLib, GObject
+from gi.repository import Adw, Gtk, GLib, GObject, Gio
 
 from .nmap_scanner import NmapScanner, NmapArgumentError, NmapScanParseError
-from .utils import discover_nse_scripts # Updated import
+from .utils import discover_nse_scripts
 
 
 @Gtk.Template(resource_path="/com/github/mclellac/NetworkMap/window.ui")
 class NetworkMapWindow(Adw.ApplicationWindow):
     __gtype_name__ = "NetworkMapWindow"
 
-    # Template children (UI elements defined in window.ui)
     target_entry_row: Adw.EntryRow = Gtk.Template.Child("target_entry_row")
     os_fingerprint_switch: Gtk.Switch = Gtk.Template.Child(
         "os_fingerprint_switch"
@@ -22,7 +20,7 @@ class NetworkMapWindow(Adw.ApplicationWindow):
     )
     nse_script_combo_row: Adw.ComboRow = Gtk.Template.Child(
         "nse_script_combo_row"
-    )  # Declared, but logic not yet implemented
+    )
     spinner: Gtk.Spinner = Gtk.Template.Child("spinner")
     text_view: Gtk.TextView = Gtk.Template.Child("text_view")
     status_page: Adw.StatusPage = Gtk.Template.Child("status_page")
@@ -35,7 +33,7 @@ class NetworkMapWindow(Adw.ApplicationWindow):
 
         self.nmap_scanner: NmapScanner = NmapScanner()
         self.current_scan_results: Optional[List[Dict[str, Any]]] = None
-        self.selected_nse_script: Optional[str] = None # For tracking selected NSE script
+        self.selected_nse_script: Optional[str] = None
 
         self._connect_signals()
         self._populate_nse_script_combo()
@@ -48,22 +46,16 @@ class NetworkMapWindow(Adw.ApplicationWindow):
 
     def _populate_nse_script_combo(self) -> None:
         """Populates the NSE script combo box with discovered scripts."""
-        discovered_scripts = discover_nse_scripts() # Use imported function
-        
-        # "None" allows the user to not select any specific script.
+        discovered_scripts = discover_nse_scripts()
         combo_items: List[str] = ["None"] + discovered_scripts
-        
         string_list_model = Gtk.StringList.new(combo_items)
         self.nse_script_combo_row.set_model(string_list_model)
-        
-        # Since "None" is always added, combo_items will have at least one element.
         self.nse_script_combo_row.set_selected(0)
 
     def _connect_signals(self) -> None:
         """Connects UI signals to their handlers."""
         self.target_entry_row.connect("apply", self._on_scan_button_clicked)
         self.nse_script_combo_row.connect("notify::selected", self._on_nse_script_selected)
-        # results_listbox rows are connected dynamically in _populate_results_listbox
 
     def _on_nse_script_selected(self, combo_row: Adw.ComboRow, pspec: GObject.ParamSpec) -> None:
         """
@@ -73,7 +65,6 @@ class NetworkMapWindow(Adw.ApplicationWindow):
         selected_index = combo_row.get_selected()
         model = combo_row.get_model()
 
-        # Ensure model is a Gtk.StringList as expected.
         if isinstance(model, Gtk.StringList) and selected_index >= 0:
             selected_value = model.get_string(selected_index)
             if selected_value == "None":
@@ -82,8 +73,6 @@ class NetworkMapWindow(Adw.ApplicationWindow):
                 self.selected_nse_script = selected_value
         else:
             self.selected_nse_script = None
-
-    # Removed _discover_nse_scripts method from here
 
     def _update_ui_state(self, state: str, message: Optional[str] = None) -> None:
         """
@@ -111,9 +100,9 @@ class NetworkMapWindow(Adw.ApplicationWindow):
                 self.status_page.set_property("description", "Scan Complete.")
             elif state == "ready":
                 self.status_page.set_property("description", message or "Ready to scan.")
-            elif state == "no_results": # Specifically for "No hosts found." from nmap_scanner
+            elif state == "no_results":
                 self.status_page.set_property("description", "Scan Complete: No hosts found.")
-            elif state == "no_data": # For cases where hosts_data is None but no specific nmap error
+            elif state == "no_data":
                  self.status_page.set_property("description", "Scan Complete: No data received.")
 
 
@@ -136,8 +125,8 @@ class NetworkMapWindow(Adw.ApplicationWindow):
                 self.arguments_entry_row.get_text(),
             ),
         )
-        thread.daemon = True
-        thread.start()
+        scan_thread.daemon = True # Corrected from thread.daemon to scan_thread.daemon
+        scan_thread.start()
 
     def _run_scan_worker(
         self, target: str, do_os_fingerprint: bool, additional_args_str: str
@@ -154,18 +143,15 @@ class NetworkMapWindow(Adw.ApplicationWindow):
         hosts_data: Optional[List[Dict[str, Any]]] = None
 
         try:
-            # NmapScanner.scan returns:
-            # hosts_data: List of host dictionaries, or None on critical error.
-            # scan_message: Optional error/info message from the scanner itself.
             hosts_data, scan_message = self.nmap_scanner.scan(
                 target,
                 do_os_fingerprint,
                 additional_args_str,
                 self.selected_nse_script,
-                default_args_str=default_args_from_settings, # Pass fetched default args
+                default_args_str=default_args_from_settings,
             )
             if scan_message and not hosts_data:
-                error_type = "ScanMessage" # Indicates message from nmap_scanner, not an exception
+                error_type = "ScanMessage"
                 error_message = scan_message
 
         except (NmapArgumentError, NmapScanParseError) as e:
@@ -187,34 +173,30 @@ class NetworkMapWindow(Adw.ApplicationWindow):
         """Handles UI updates after the Nmap scan worker finishes."""
         if error_type:
             self._display_scan_error(error_type, error_message or "Unknown error.")
-            if error_message == "No hosts found.": # Specific case from nmap_scanner
+            if error_message == "No hosts found.":
                  self._update_ui_state("no_results")
-                 self.current_scan_results = [] # Treat as empty result set
-            else: # Other errors (argument, parse, execution, unexpected)
+                 self.current_scan_results = []
+            else:
                 self._update_ui_state("error", error_message)
                 self.current_scan_results = None
-        elif hosts_data is None: # No explicit error_type, but no data either
+        elif hosts_data is None:
             self._clear_results_ui()
             self._set_text_view_text("No data received from scan.")
             self._update_ui_state("no_data")
             self.current_scan_results = None
-        elif not hosts_data: # Empty list of hosts
+        elif not hosts_data:
             self._clear_results_ui()
             self._set_text_view_text("No hosts were found matching the criteria.")
             self._update_ui_state("no_results")
             self.current_scan_results = []
-        else: # Successful scan with results
+        else:
             self.current_scan_results = hosts_data
             self._populate_results_listbox(hosts_data)
             self._set_text_view_text("Select a host from the list to see its scan details.")
             self._update_ui_state("success")
         
-        # Ensure UI elements like spinner and input fields are reset correctly.
-        # _update_ui_state handles most of this based on the final state.
-        # Explicitly ensure spinner is off if not already handled by _update_ui_state.
         if self.spinner.get_visible():
              self.spinner.set_visible(False)
-        # Ensure input fields are enabled if not in a scanning state.
         if not self.target_entry_row.get_sensitive() and self.status_page.get_property("description") != "Scanning...":
             self.target_entry_row.set_sensitive(True)
             self.arguments_entry_row.set_sensitive(True)
@@ -223,17 +205,12 @@ class NetworkMapWindow(Adw.ApplicationWindow):
 
     def _clear_results_ui(self) -> None:
         """Clears the results listbox and the text view display."""
-        # Efficiently clear ListBox by removing children.
-        # Hiding/showing the listbox can prevent excessive redraws if removal is slow,
-        # but for typical result sizes, direct removal should be fine.
         while child := self.results_listbox.get_row_at_index(0):
             self.results_listbox.remove(child)
-        
         self._set_text_view_text("")
 
     def _populate_results_listbox(self, hosts_data: List[Dict[str, Any]]) -> None:
         """Populates the results_listbox with discovered hosts from scan data."""
-        # self.results_listbox.set_visible(False) # Optional: hide during bulk update
         for host_data in hosts_data:
             row = Adw.ActionRow()
             title = host_data.get("hostname") or host_data.get("id", "Unknown Host")
@@ -241,17 +218,13 @@ class NetworkMapWindow(Adw.ApplicationWindow):
             row.set_subtitle(f"State: {host_data.get('state', 'N/A')}")
             row.set_icon_name("computer-symbolic")
             row.set_activatable(True)
-            # Storing index is simpler if current_scan_results is guaranteed to match.
             row.connect("activated", self._on_host_row_activated)
             self.results_listbox.append(row)
-        # self.results_listbox.set_visible(True) # Optional: show after bulk update
 
     def _display_scan_error(self, error_type: str, error_message: str) -> None:
         """Displays scan-related errors in the text_view."""
-        self._clear_results_ui() # Clear previous results before showing an error
+        self._clear_results_ui()
         self._set_text_view_text(f"Error Type: {error_type}\n\nMessage: {error_message}")
-        # Consider using Adw.Toast for less critical/more transient errors in the future.
-        # e.g., toast = Adw.Toast.new(f"Scan Error: {error_message[:100]}"); self.add_toast(toast);
 
     def _on_host_row_activated(self, row: Adw.ActionRow) -> None:
         """
@@ -274,5 +247,4 @@ class NetworkMapWindow(Adw.ApplicationWindow):
         if details:
             self._set_text_view_text(details)
         else:
-            # This case should ideally be rare if raw_details_text is always populated
             self._set_text_view_text(f"No detailed scan information available for {row.get_title()}.")


### PR DESCRIPTION
This commit addresses two main issues:
1.  Corrects the Python module installation in `src/meson.build`:
    - Uses `py_installation.install_sources()` instead of the incorrect `python.install_sources()`. `py_installation` is obtained from `python.find_installation('python3', required: true)`.
    - This ensures Python sources are installed to the standard `site-packages` directory correctly.

2.  Performs an aggressive cleanup of comments across all Python source files in `src/`:
    - All single-line comments (`# ...`) that are not essential for understanding genuinely complex or non-obvious code logic have been removed.
    - Docstrings (module, class, and function/method) have been preserved.
    - This addresses your feedback requesting removal of all comments deemed "stupid" or self-explanatory (e.g., `# Local imports`, `# Some constant`, etc.).
    - A typo (`thread.daemon = True` to `scan_thread.daemon = True`) was also corrected in `src/window.py` during this process.