### PR TITLE
Revert to standard Python site-packages installation

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -1,5 +1,4 @@
 pkgdatadir = get_option('prefix') / get_option('datadir') / meson.project_name()
-moduledir = pkgdatadir / 'networkmap'
 gnome = import('gnome')
 
 gnome.compile_resources('networkmap',
@@ -36,7 +35,7 @@ networkmap_sources = [
   'utils.py', # Updated path
 ]
 
-install_data(
+py_installation.install_sources(
   networkmap_sources,
-  install_dir: moduledir
+  subdir: 'networkmap'
 )

--- a/src/networkmap.in
+++ b/src/networkmap.in
@@ -11,12 +11,6 @@ conf = {
     'pkgdatadir': '@pkgdatadir@'
 }
 
-# Ensure the package installed in pkgdatadir can be found.
-# conf['pkgdatadir'] (e.g., /usr/local/share/networkmap) is added to sys.path.
-# The Python module 'networkmap' is installed in conf['pkgdatadir'] / 'networkmap'.
-if conf['pkgdatadir'] not in sys.path:
-    sys.path.insert(0, conf['pkgdatadir'])
-
 # 2. Load GResources
 try:
     from gi.repository import Gio, GLib # Import GLib for GLib.Error


### PR DESCRIPTION
This commit updates the Meson build system to install the application's Python code into the standard Python `site-packages` directory. This addresses your feedback requesting this installation method.

Changes:
- In `src/meson.build`:
    - Uses `py_installation.install_sources(..., subdir='networkmap')` to ensure the Python module is installed as a package into the standard `site-packages` location.
    - Removed the `moduledir` variable previously used for custom path installation of Python sources.
- In `src/networkmap.in` (launcher script):
    - Removed the custom `sys.path.insert(0, conf['pkgdatadir'])` logic, as the Python module should now be found via standard import paths.

This reverts the installation strategy to a standard one. Next, I will diagnose any runtime errors (e.g., related to GObject Introspection finding 'Adw') that occur with this setup in your environment.