### PR TITLE
Fix: Correct SyntaxError and Font Preference Application

### DIFF
--- a/src/nmap_scanner.py
+++ b/src/nmap_scanner.py
@@ -137,9 +137,6 @@ class NmapScanner:
         return None, "Scan failed due to an unexpected internal error."
 
     def _build_scan_args(
-            return None, f"An unexpected error occurred during scan ({type(e).__name__}): {e}"
-
-    def _build_scan_args(
         self,
         do_os_fingerprint: bool,
         additional_args_str: str,


### PR DESCRIPTION
This commit addresses two critical issues:

1.  **SyntaxError in nmap_scanner.py:**
    - Removed extraneous and misplaced lines of code around the `_build_scan_args` method definition in `src/nmap_scanner.py`, which were causing a `SyntaxError: '(' was never closed`.

2.  **Font Preference Application (AttributeError & Deprecation):**
    - Replaced the deprecated `override_font()` method for styling the results `Gtk.TextView` in `src/window.py`.
    - Implemented font styling using `Gtk.CssProvider`.
    - A `Gtk.CssProvider` is now associated with the results `Gtk.TextView`.
    - The `_apply_font_preference` method dynamically loads CSS (e.g., `* { font: "Family Sizept"; }`) into this provider based on the 'results-font' GSetting.
    - This ensures that your font preferences are correctly applied at startup and update dynamically when changed.

These fixes restore application stability and correct font customization.