### PR TITLE
Fix: Refine CSS application for font preferences

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -1,3 +1,4 @@
+import sys
 import threading
 from typing import Optional, List, Dict, Any, Tuple
 
@@ -47,24 +48,40 @@ class NetworkMapWindow(Adw.ApplicationWindow):
         self._update_ui_state("ready")
 
     def _apply_font_preference(self) -> None:
-        """Applies the font preference from GSettings to the results text_view using CSS."""
-        font_str = self.settings.get_string("results-font") # Assumes self.settings is initialized
-            
-        css_data = "" # Default to empty CSS (clear override)
+        # Applies the font preference from GSettings to the results text_view using specific CSS properties.
+        font_str = self.settings.get_string("results-font")
+        print(f"DEBUG: Font string from GSettings: '{font_str}'", file=sys.stderr)
+
+        css_data = ""  # Default to empty CSS (clear override)
         if font_str:
-            # Pango font description like "Monospace 12" is generally okay for "font:" CSS property in GTK.
-            # Escape any special characters in font_str if necessary, though typically font names are simple.
-            # For CSS, if font_str contains spaces, it might need quoting, but Pango format "Family Style Size"
-            # is usually fine for Gtk's `font` CSS property.
-            css_data = f"* {{ font: {font_str}; }}"
-            
-        # Ensure self.font_css_provider is initialized before calling this
+            try:
+                font_desc = Pango.FontDescription.from_string(font_str)
+                family = font_desc.get_family()
+                size_points = 0
+                
+                if font_desc.get_size_is_set(): # Check if size was explicitly set in the description
+                    size_points = font_desc.get_size() / Pango.SCALE
+                
+                print(f"DEBUG: Parsed - Family: '{family}', Size Points: {size_points}", file=sys.stderr)
+
+                if family and size_points > 0:
+                    css_data = f"* {{ font-family: \"{family}\"; font-size: {size_points}pt; }}"
+                elif family: # Only family is reliably parsed or size is 0/default
+                    css_data = f"* {{ font-family: \"{family}\"; }}" # Apply only family, let size be default
+                    print(f"DEBUG: Applying family only: '{family}'", file=sys.stderr)
+                else:
+                    # This case means Pango.FontDescription couldn't even get a family name.
+                    print(f"Warning: Could not parse family name effectively from font string '{font_str}'. CSS will be empty.", file=sys.stderr)
+            except Exception as e:
+                # Handles errors from Pango.FontDescription.from_string() if font_str is malformed
+                print(f"Error parsing font string '{font_str}' with Pango: {e}. CSS will be empty.", file=sys.stderr)
+        
+        print(f"DEBUG: Generated CSS data: '{css_data}'", file=sys.stderr)
+
         if hasattr(self, 'font_css_provider'):
             self.font_css_provider.load_from_data(css_data.encode())
         else:
-            # This case should ideally not happen if __init__ is structured correctly
-            # Consider logging to sys.stderr if available and appropriate for the app
-            print("Error: font_css_provider not initialized before applying font preference.")
+            print("Error: font_css_provider not initialized before applying font preference.", file=sys.stderr)
 
     def _set_text_view_text(self, message: str) -> None:
         """Sets the text of the text_view's buffer if it exists."""


### PR DESCRIPTION
This commit further refines the font preference system for the results Gtk.TextView, which was still not applying correctly.

The `_apply_font_preference` method in `src/window.py` has been updated to:
- Parse the font string from GSettings (key: "results-font") using `Pango.FontDescription.from_string()`.
- Extract the font family and size (in points) from the Pango.FontDescription object.
- Construct a more specific CSS string using `font-family: "{family}"; font-size: {size_points}pt;`. This provides better control than the shorthand `font:` property.
- Handle cases where only the font family might be available or if the font size is not explicitly set.
- Apply this CSS data to the `Gtk.CssProvider` associated with the results `Gtk.TextView`.
- Added detailed debug logging to stderr to trace the font string retrieved from GSettings, the parsed family/size, and the generated CSS. This will aid in any future troubleshooting.

This more robust approach to generating and applying CSS for font styling should resolve the issues where font preferences were not being correctly reflected in the UI.