### PR TITLE
Feat: Implement Tabbed Scanning Interface with Adw.TabView

### DIFF
--- a/src/gtk/scan_page.ui
+++ b/src/gtk/scan_page.ui
@@ -1,0 +1,125 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Created with Cambalache 0.96.1 -->
+<interface>
+  <!-- interface-name scan_page.ui -->
+  <requires lib="gio" version="2.44"/>
+  <requires lib="gtk" version="4.18"/>
+  <requires lib="libadwaita" version="1.7"/>
+  <template class="ScanPage" parent="GtkBox">
+    <property name="orientation">vertical</property>
+    <property name="spacing">0</property> <!-- Adjust as needed -->
+    <child>
+      <object class="AdwToastOverlay" id="toast_overlay">
+        <property name="child">
+          <object class="AdwStatusPage" id="status_page">
+            <property name="description">Perform an nmap scan on a target host or network.</property>
+            <property name="halign">fill</property> <!-- Changed from baseline-fill -->
+            <property name="icon-name">network-server-symbolic</property>
+            <property name="title">Scan host(s)</property>
+            <property name="vexpand">True</property>
+            <child>
+              <object class="AdwClamp">
+                <property name="maximum-size">800</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="halign">fill</property> <!-- Changed from baseline-fill -->
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">10</property>
+                    <property name="valign">fill</property> <!-- Changed from baseline-fill -->
+                    <child>
+                      <object class="GtkListBox">
+                        <property name="css-classes">boxed-list</property>
+                        <property name="margin-bottom">15</property>
+                        <child>
+                          <object class="AdwEntryRow" id="target_entry_row">
+                            <property name="show-apply-button">True</property>
+                            <property name="title">Target/CIDR</property>
+                          </object>
+                        </child>
+                        <child>
+                          <!-- OS Fingerprint Switch -->
+                          <object class="AdwActionRow" id="os_fingerprint_row">
+                            <property name="title">OS Fingerprinting</property>
+                            <property name="subtitle">Requires root</property>
+                            <child>
+                              <object class="GtkSwitch" id="os_fingerprint_switch">
+                                <property name="valign">center</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="AdwExpanderRow">
+                            <property name="expanded">False</property>
+                            <property name="title">Advanced Options</property>
+                            <child>
+                              <object class="AdwEntryRow" id="arguments_entry_row">
+                                <property name="title">Additional Arguments</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="AdwComboRow" id="nse_script_combo_row">
+                                <property name="subtitle">Include execution of NSE script</property>
+                                <property name="title">NSE Script</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkSpinner" id="spinner">
+                        <property name="focus-on-click">False</property>
+                        <property name="halign">center</property>
+                        <property name="height-request">32</property>
+                        <property name="margin-bottom">5</property>
+                        <property name="margin-top">5</property>
+                        <property name="overflow">hidden</property>
+                        <property name="valign">center</property>
+                        <property name="width-request">32</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkBox"> <!-- For results_listbox and text_view side-by-side -->
+                        <property name="orientation">horizontal</property>
+                        <property name="spacing">10</property>
+                        <property name="hexpand">True</property>
+                        <property name="vexpand">True</property>
+                        <child>
+                          <object class="GtkScrolledWindow">
+                            <property name="hscrollbar-policy">never</property>
+                            <property name="min-content-width">200</property> <!-- Example width -->
+                            <property name="vexpand">True</property>
+                            <child>
+                              <object class="GtkListBox" id="results_listbox">
+                                <property name="css-classes">boxed-list</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                        <child>
+                           <object class="GtkScrolledWindow">
+                             <property name="hexpand">True</property>
+                             <property name="vexpand">True</property>
+                             <child>
+                               <object class="GtkTextView" id="text_view">
+                                 <property name="hexpand">True</property>
+                                 <property name="vexpand">True</property>
+                                 <property name="editable">False</property>
+                                 <property name="cursor-visible">False</property>
+                               </object>
+                             </child>
+                           </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </property>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/src/main.py
+++ b/src/main.py
@@ -54,6 +54,7 @@ class NetworkMapApplication(Adw.Application):
         self.create_action("about", self._on_about_action)
         self.create_action("preferences", self._on_preferences_action, ["<primary>comma"])
         self.create_action("help_shortcuts", self._on_help_shortcuts_action, ["<Control>question", "F1"])
+        self.create_action("new_tab", self._on_new_tab_action, ["<primary>t"])
 
         self._apply_initial_theme()
 
@@ -112,6 +113,16 @@ class NetworkMapApplication(Adw.Application):
 
         prefs_window = NetworkMapPreferencesWindow(parent_window=active_window)
         prefs_window.present()
+
+    def _on_new_tab_action(self, action: Gio.SimpleAction, parameter: Optional[GLib.Variant]) -> None:
+        """Handles the 'new_tab' action by telling the active window to add a new tab."""
+        win = self.get_active_window()
+        if isinstance(win, NetworkMapWindow): # Ensure it's our main window
+            win._add_new_tab()
+        elif win: # Active window exists but is not NetworkMapWindow
+            print(f"Warning: Action 'app.new_tab' called, but active window is not NetworkMapWindow. Type: {type(win)}", file=sys.stderr)
+        # If no active window, do nothing (or log if necessary)
+
 
     def _on_help_shortcuts_action(self, action: Gio.SimpleAction, parameter: Optional[GLib.Variant]) -> None:
         """Handles the 'help_shortcuts' action by displaying the shortcuts window."""

--- a/src/meson.build
+++ b/src/meson.build
@@ -35,6 +35,7 @@ networkmap_sources = [
   'nmap_scanner.py',
   'preferences_window.py',
   'utils.py',
+  'scan_page.py',
 ]
 
 py_installation.install_sources(

--- a/src/networkmap.gresource.xml
+++ b/src/networkmap.gresource.xml
@@ -3,6 +3,7 @@
   <gresource prefix="/com/github/mclellac/NetworkMap">
     <file preprocess="xml-stripblanks">window.ui</file>
     <file preprocess="xml-stripblanks">gtk/help-overlay.ui</file>
-        <file preprocess="xml-stripblanks">gtk/preferences.ui</file> 
+    <file preprocess="xml-stripblanks">gtk/preferences.ui</file>
+    <file preprocess="xml-stripblanks">gtk/scan_page.ui</file>
   </gresource>
 </gresources>

--- a/src/scan_page.py
+++ b/src/scan_page.py
@@ -1,0 +1,151 @@
+import sys # For initial debug print
+import gi
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+from gi.repository import Gtk, Adw, Gio, GLib, GObject, Pango
+
+# Import NmapScanner related items if type hinting or direct use is needed in ScanPage later
+# For now, scan initiation is in NetworkMapWindow, so direct NmapScanner import might not be needed here.
+# from .nmap_scanner import NmapScanner, NmapArgumentError, NmapScanParseError
+from .utils import discover_nse_scripts # Needed for _populate_nse_script_combo
+from typing import Optional, List, Dict, Any # For type hints
+
+
+@Gtk.Template(resource_path="/com/github/mclellac/NetworkMap/gtk/scan_page.ui")
+class ScanPage(Gtk.Box): # Matching parent in scan_page.ui
+    __gtype_name__ = "ScanPage"
+
+    # Define Gtk.Template.Child references for all UI elements from scan_page.ui
+    toast_overlay: Adw.ToastOverlay = Gtk.Template.Child("toast_overlay")
+    status_page: Adw.StatusPage = Gtk.Template.Child("status_page")
+    target_entry_row: Adw.EntryRow = Gtk.Template.Child("target_entry_row")
+    # For AdwActionRow containing a Gtk.Switch, the switch itself is the child to control.
+    # The AdwActionRow can be a child if needed for other interactions.
+    os_fingerprint_row: Adw.ActionRow = Gtk.Template.Child("os_fingerprint_row") # The row itself
+    os_fingerprint_switch: Gtk.Switch = Gtk.Template.Child("os_fingerprint_switch") # The switch inside the row
+    arguments_entry_row: Adw.EntryRow = Gtk.Template.Child("arguments_entry_row")
+    nse_script_combo_row: Adw.ComboRow = Gtk.Template.Child("nse_script_combo_row")
+    spinner: Gtk.Spinner = Gtk.Template.Child("spinner")
+    results_listbox: Gtk.ListBox = Gtk.Template.Child("results_listbox")
+    text_view: Gtk.TextView = Gtk.Template.Child("text_view")
+
+    def __init__(self, app_window, **kwargs):
+        super().__init__(**kwargs)
+        self.app_window = app_window  # Keep a reference to the main window
+        self.text_buffer = self.text_view.get_buffer()
+
+        self.current_scan_results: Optional[List[Dict[str, Any]]] = None
+        self.selected_nse_script: Optional[str] = None
+
+        # Apply font preference CSS provider from the main window
+        if hasattr(self.app_window, 'font_css_provider') and self.app_window.font_css_provider:
+            self.text_view.get_style_context().add_provider(
+                self.app_window.font_css_provider,
+                Gtk.STYLE_PROVIDER_PRIORITY_USER
+            )
+        # The main window's _apply_font_preference (which updates the provider's data)
+        # will be called by the main window when the GSetting changes or initially.
+
+        self._connect_signals()
+        self._populate_nse_script_combo()
+        self.update_ui_state("ready")
+        
+        print(f"ScanPage created. Initial target: '{self.target_entry_row.get_text()}'", file=sys.stderr)
+
+    def _connect_signals(self) -> None:
+        """Connects UI signals to their handlers for this page."""
+        self.target_entry_row.connect("apply", self._on_scan_button_clicked_page)
+        self.nse_script_combo_row.connect("notify::selected", self._on_nse_script_selected_page)
+        # results_listbox selection handled by populate_results_listbox connecting _on_host_row_activated
+
+    def _on_scan_button_clicked_page(self, entry: Adw.EntryRow) -> None:
+        """Callback for when the scan is initiated from this page's target entry row."""
+        # Delegate to the main window to initiate the scan for this specific page
+        self.app_window._initiate_scan_for_page(self)
+
+    def _on_nse_script_selected_page(self, combo_row: Adw.ComboRow, pspec: GObject.ParamSpec) -> None:
+        """Handles the selection change in this page's NSE script combo box."""
+        selected_index = combo_row.get_selected()
+        model = combo_row.get_model()
+        if isinstance(model, Gtk.StringList) and selected_index >= 0:
+            selected_value = model.get_string(selected_index)
+            self.selected_nse_script = None if selected_value == "None" else selected_value
+        else:
+            self.selected_nse_script = None
+
+    def _populate_nse_script_combo(self) -> None:
+        """Populates this page's NSE script combo box."""
+        discovered_scripts = discover_nse_scripts() 
+        combo_items: List[str] = ["None"] + discovered_scripts
+        string_list_model = Gtk.StringList.new(combo_items)
+        self.nse_script_combo_row.set_model(string_list_model)
+        self.nse_script_combo_row.set_selected(0)
+        self.selected_nse_script = None # Initialize selection
+
+    def update_ui_state(self, state: str, message: Optional[str] = None) -> None:
+        """Updates UI elements based on application state for this page."""
+        if state == "scanning":
+            self.spinner.set_visible(True)
+            self.status_page.set_property("description", "Scanning...")
+            self.target_entry_row.set_sensitive(False)
+            self.arguments_entry_row.set_sensitive(False)
+            self.os_fingerprint_switch.set_sensitive(False) # Accessing switch directly
+            self.nse_script_combo_row.set_sensitive(False)
+        else:
+            self.spinner.set_visible(False)
+            self.target_entry_row.set_sensitive(True)
+            self.arguments_entry_row.set_sensitive(True)
+            self.os_fingerprint_switch.set_sensitive(True)
+            self.nse_script_combo_row.set_sensitive(True)
+
+            status_description = ""
+            if state == "error":
+                status_description = f"Scan Failed: {message or 'Unknown error'}"
+            elif state == "success":
+                status_description = "Scan Complete."
+            elif state == "ready":
+                status_description = message or "Ready to scan."
+            elif state == "no_results":
+                status_description = "Scan Complete: No hosts found."
+            elif state == "no_data":
+                status_description = "Scan Complete: No data received."
+            self.status_page.set_property("description", status_description)
+
+    def set_text_view_text(self, message: str) -> None:
+        """Sets the text of this page's text_view's buffer."""
+        if self.text_buffer:
+            self.text_buffer.set_text(message)
+
+    def clear_results_ui(self) -> None:
+        """Clears this page's results listbox and the text view display."""
+        while child := self.results_listbox.get_row_at_index(0):
+            self.results_listbox.remove(child)
+        self.set_text_view_text("")
+
+    def populate_results_listbox(self, hosts_data: List[Dict[str, Any]]) -> None:
+        """Populates this page's results_listbox with discovered hosts."""
+        self.clear_results_ui() # Clear previous results first
+        for host_data in hosts_data:
+            row = Adw.ActionRow()
+            title = host_data.get("hostname") or host_data.get("id", "Unknown Host")
+            row.set_title(title)
+            row.set_subtitle(f"State: {host_data.get('state', 'N/A')}")
+            row.set_icon_name("computer-symbolic") # Example icon
+            row.set_activatable(True)
+            row.connect("activated", self._on_host_row_activated)
+            self.results_listbox.append(row)
+
+    def _on_host_row_activated(self, row: Adw.ActionRow) -> None:
+        """Handles activation of a host row in this page's results_listbox."""
+        host_index: int = row.get_index()
+        if self.current_scan_results and 0 <= host_index < len(self.current_scan_results):
+            host_data: Dict[str, Any] = self.current_scan_results[host_index]
+            details: Optional[str] = host_data.get("raw_details_text")
+            self.set_text_view_text(details or f"No detailed scan information available for {row.get_title()}.")
+        else:
+            self.set_text_view_text(f"Error: Invalid host selection or results unavailable (index {host_index}).")
+
+    def display_scan_error(self, error_type: str, error_message: str) -> None:
+        """Displays scan-related errors in this page's text_view."""
+        self.clear_results_ui()
+        self.set_text_view_text(f"Error Type: {error_type}\n\nMessage: {error_message}")

--- a/src/window.ui
+++ b/src/window.ui
@@ -10,6 +10,16 @@
       <object class="AdwToolbarView">
         <child type="top">
           <object class="AdwHeaderBar">
+            <child type="start">
+              <object class="GtkButton" id="new_tab_button">
+                <property name="action-name">app.new_tab</property>
+                <property name="icon-name">document-new-symbolic</property>
+                <property name="tooltip-text" translatable="yes">New Scan Tab</property>
+              </object>
+            </child>
+            <property name="title-widget">
+              <object class="AdwTabBar" id="tab_bar"/>
+            </property>
             <child type="end">
               <object class="GtkMenuButton">
                 <property name="icon-name">open-menu-symbolic</property>
@@ -20,102 +30,11 @@
             </child>
           </object>
         </child>
-        <child>
-          <object class="AdwToastOverlay" id="toast_overlay">
-            <property name="child">
-              <object class="AdwStatusPage" id="status_page">
-                <property name="description">Perform an nmap scan on a target host or network.</property>
-                <property name="halign">baseline-fill</property>
-            <property name="icon-name">network-server-symbolic</property>
-            <property name="title">Scan host(s)</property>
-            <property name="vexpand">True</property>
-            <child>
-              <object class="AdwClamp">
-                <property name="maximum-size">800</property>
-                <child>
-                  <object class="GtkBox">
-                    <property name="halign">baseline-fill</property>
-                    <property name="orientation">vertical</property>
-                    <property name="spacing">10</property>
-                    <property name="valign">baseline-fill</property>
-                    <child>
-                      <object class="GtkListBox">
-                        <property name="css-classes">boxed-list</property>
-                        <property name="margin-bottom">15</property>
-                        <child>
-                          <object class="AdwEntryRow" id="target_entry_row">
-                            <property name="show-apply-button">True</property>
-                            <property name="title">Target/CIDR</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="AdwSwitchRow" id="os_fingerprint_switch">
-                            <property name="subtitle">Requires root</property>
-                            <property name="title">OS Fingerprinting</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="AdwExpanderRow">
-                            <property name="expanded">False</property>
-                            <property name="title">Advanced Options</property>
-                            <child>
-                              <object class="AdwEntryRow" id="arguments_entry_row">
-                                <property name="title">Additional Arguments</property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="AdwComboRow" id="nse_script_combo_row">
-                                <property name="subtitle">Include execution of NSE script</property>
-                                <property name="title">NSE Script</property>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="AdwSpinner" id="spinner">
-                        <property name="focus-on-click">False</property>
-                        <property name="halign">center</property>
-                        <property name="height-request">32</property>
-                        <property name="margin-bottom">5</property>
-                        <property name="margin-top">5</property>
-                        <property name="overflow">hidden</property>
-                        <property name="valign">center</property>
-                        <property name="width-request">32</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkBox">
-                        <child>
-                          <object class="GtkListBox" id="results_listbox">
-                            <property name="css-classes">boxed-list</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkFrame">
-                            <property name="hexpand">True</property>
-                            <property name="margin-start">15</property>
-                            <property name="vexpand">True</property>
-                            <child>
-                              <object class="GtkTextView" id="text_view">
-                                <property name="hexpand">True</property>
-                                <property name="vexpand">True</property>
-                                <property name="vexpand-set">True</property>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
+        <property name="content">
+          <object class="AdwTabView" id="tab_view">
+            <!-- Initially, the TabView will have no pages defined in the UI -->
           </object>
         </property>
-      </object>
-    </child>
   </object>
 </property>
     <!-- Closes <property name="content"> -->


### PR DESCRIPTION
This commit introduces a major refactoring to support a tabbed user interface using Adw.TabView, allowing you to manage multiple scan sessions simultaneously.

Key changes include:

1.  **UI Structure (`src/window.ui`):**
    - `NetworkMapWindow`'s main content is now an `Adw.TabView`.
    - An `Adw.TabBar` has been added to the header bar for tab navigation.

2.  **ScanPage Widget (`src/scan_page.py`, `src/gtk/scan_page.ui`):**
    - Created a new `ScanPage` widget (subclassing `Gtk.Box`) to encapsulate all UI elements and logic for a single scan session (target inputs, scan controls, results list, detailed output view, status page, toast overlay).
    - The UI for `ScanPage` is defined in `gtk/scan_page.ui` and loaded via `Gtk.Template`.

3.  **Window Logic (`src/window.py` - `NetworkMapWindow`):**
    - Manages the `Adw.TabView` and `Adw.TabBar`.
    - Handles creation of new tabs (`_add_new_tab`), each containing a `ScanPage` instance.
    - An initial "Network Scan" tab is created on startup.
    - Scan initiation logic (`_initiate_scan_for_page`) is now parameterized to operate on a specific `ScanPage`.
    - Scan and completion methods (`_run_scan`, `_process_scan_completion`) are updated to pass and use the relevant `ScanPage` for UI updates.
    - Font preferences (`font_css_provider`) are managed by `NetworkMapWindow` and applied to each `ScanPage`'s text view.

4.  **Application Logic (`src/main.py` - `NetworkMapApplication`):**
    - Added a "new_tab" action (`app.new_tab` with accelerator Ctrl+T) to create new scan tabs.
    - A "New Tab" button is added to the header bar in `window.ui`.

5.  **Tab Management Features:**
    - Tab titles are updated with the scan target upon scan completion.
    - If the last tab is closed, a new default "Network Scan" tab is automatically created to prevent an empty window state.

6.  **Build System & Resources:**
    - `scan_page.py` added to sources in `src/meson.build`.
    - `gtk/scan_page.ui` added to `src/networkmap.gresource.xml`.

This refactoring significantly improves the application's usability by allowing multiple scans to be managed in a familiar tabbed interface. Core scan logic is now better encapsulated within the `ScanPage` widget.