### PR TITLE
Fix: Correct Adw.TabView signal for page closure handling

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -68,11 +68,12 @@ class NetworkMapWindow(Adw.ApplicationWindow):
             else:
                  print("ERROR (NetworkMapWindow): No pages in tab_view after trying to add initial tab and _add_new_tab returned None.", file=sys.stderr)
         
-        self.tab_view.connect("close-page-done", self._on_tab_view_page_closed)
+        self.tab_view.connect("pages-changed", self._on_tab_view_pages_changed)
 
 
-    def _on_tab_view_page_closed(self, tab_view: Adw.TabView, page: Adw.TabPage) -> None:
-        # Handles the scenario after a tab is closed, ensuring a new default tab is created if none are left.
+    def _on_tab_view_pages_changed(self, tab_view: Adw.TabView) -> None:
+        # Handles the scenario after pages have changed (e.g., a tab is closed),
+        # ensuring a new default tab is created if none are left.
         if tab_view.get_n_pages() == 0:
             # Create a new tab. _add_new_tab will handle setting it as selected
             # and will title it "New Scan" if target is None and set_title=True.


### PR DESCRIPTION
This commit resolves a TypeError that occurred at startup due to an incorrect signal name being used for Adw.TabView.

- In `NetworkMapWindow.__init__` (src/window.py), the signal connection for detecting when tabs are closed and potentially re-creating a default tab was changed from the non-existent "close-page-done" to the correct "pages-changed" signal.
- The corresponding callback method was renamed from `_on_tab_view_page_closed` to `_on_tab_view_pages_changed`, and its signature was adjusted to `(self, tab_view: Adw.TabView)` as the `page` parameter is not reliably provided by `pages-changed` for this use case.

This fix ensures the application starts correctly and that the logic for handling the closure of the last tab (by creating a new default tab) is properly triggered.