### PR TITLE
Fix: Correct Adw.TabView signal to `page-detached` for page closure

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -68,12 +68,13 @@ class NetworkMapWindow(Adw.ApplicationWindow):
             else:
                  print("ERROR (NetworkMapWindow): No pages in tab_view after trying to add initial tab and _add_new_tab returned None.", file=sys.stderr)
         
-        self.tab_view.connect("pages-changed", self._on_tab_view_pages_changed)
+        # Corrected signal connection for handling the "last tab closed" scenario
+        self.tab_view.connect("page-detached", self._on_tab_view_page_detached)
 
 
-    def _on_tab_view_pages_changed(self, tab_view: Adw.TabView) -> None:
-        # Handles the scenario after pages have changed (e.g., a tab is closed),
-        # ensuring a new default tab is created if none are left.
+    def _on_tab_view_page_detached(self, tab_view: Adw.TabView, page: Adw.TabPage) -> None:
+        # Handles the scenario after a page is detached (closed).
+        # If no pages remain, a new default tab is created.
         if tab_view.get_n_pages() == 0:
             # Create a new tab. _add_new_tab will handle setting it as selected
             # and will title it "New Scan" if target is None and set_title=True.


### PR DESCRIPTION
This commit resolves a persistent TypeError at startup caused by using incorrect signal names for Adw.TabView when handling page closure events.

- In `NetworkMapWindow.__init__` (src/window.py), the signal connection for `Adw.TabView` used to detect when the last tab is closed (to create a new default tab) is now correctly set to "page-detached".
- Previous incorrect connections (e.g., "close-page-done", "pages-changed") have been removed.
- The corresponding callback method is now `_on_tab_view_page_detached` with the correct signature `(self, tab_view: Adw.TabView, page: Adw.TabPage)`.

This change ensures the application starts correctly without signal-related TypeErrors and that the "last tab closed" behavior functions as intended.