### PR TITLE
Refactor results display using Adw.ExpanderRow

### DIFF
--- a/src/window.ui
+++ b/src/window.ui
@@ -90,22 +90,11 @@
                         <child>
                           <object class="GtkListBox" id="results_listbox">
                             <property name="css-classes">boxed-list</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkFrame">
                             <property name="hexpand">True</property>
-                            <property name="margin-start">15</property>
                             <property name="vexpand">True</property>
-                            <child>
-                              <object class="GtkTextView" id="text_view">
-                                <property name="hexpand">True</property>
-                                <property name="vexpand">True</property>
-                                <property name="vexpand-set">True</property>
-                              </object>
-                            </child>
                           </object>
                         </child>
+                        <!-- The GtkFrame and GtkTextView that were here are now removed -->
                       </object>
                     </child>
                   </object>


### PR DESCRIPTION
Replaces the previous Gtk.ListBox and Gtk.TextView combination for displaying Nmap scan results with a more integrated approach using Adw.ExpanderRow.

Key changes:
- Each host from the scan results is now presented as an Adw.ExpanderRow in the results list.
- The title of the expander row shows the hostname/IP and state.
- Expanding a row reveals a Gtk.TextView containing the detailed scan output for that host, including open ports, services, and OS information if available.
- Pango markup (bolding) has been added to the raw_details_text generation in nmap_scanner.py to improve the readability of key labels in the scan details.
- The Gtk.TextViews within the expander rows are configured to render this Pango markup.
- Font preferences from GSettings are now correctly applied to these dynamically created Gtk.TextViews.
- The main window layout has been updated to remove the old static Gtk.TextView area, giving more space to the results list.
- Error messages and application states are now primarily displayed using the Adw.StatusPage and Adw.ToastOverlay for better user feedback.