### PR TITLE
Fix: Correct Adw.Frame to Gtk.Frame

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -345,7 +345,7 @@ class HostInfoExpanderRow(Adw.ExpanderRow):
             )
 
 
-        frame = Adw.Frame() # No label for the frame, details are implicit
+        frame = Gtk.Frame() # No label for the frame, details are implicit
         frame.set_child(self._text_view)
         
         # Add some padding or margin to the frame or textview if needed


### PR DESCRIPTION
Resolves an AttributeError in HostInfoExpanderRow caused by attempting to instantiate Adw.Frame(), which does not exist. Changed to Gtk.Frame() as intended.