### PR TITLE
Feat: Restore and enhance NSE script selection

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -24,26 +24,56 @@ def discover_nse_scripts() -> List[str]:
         A sorted list of script names (without .nse extension).
         Returns an empty list if the directory is not accessible or an error occurs.
     """
-    script_names: List[str] = []
+    categorized_scripts: List[Tuple[str, str]] = []
     default_path = "/usr/share/nmap/scripts/"
+
+    # Define common prefixes for categorization
+    # Using "zzz_" for the default category ensures it sorts last.
+    DEFAULT_CATEGORY = "zzz_other"
+    SCRIPT_PREFIXES = [
+        'http', 'smb', 'dns', 'ssh', 'smtp', 'ftp', 'imap', 'pop3', 
+        'mysql', 'oracle', 'ms-sql', 'rdp', 'vnc', 'ssl', 'tls', 'snmp', 'whois',
+        'broadcast', 'discovery', 'dos', 'exploit', 'external', 'fuzzer', 
+        'intrusive', 'malware', 'safe', 'version', 'vuln' 
+        # 'auth' can be too generic, consider if it's needed or if specific auth types are better
+    ]
+
 
     if not os.path.isdir(default_path) or not os.access(default_path, os.R_OK):
         logging.warning(f"NSE script directory {default_path} not found or not readable.")
-        return script_names
+        return [] # Return empty list as per original behavior
 
     try:
         for item_name in os.listdir(default_path):
             if item_name.endswith(".nse"):
                 full_item_path = os.path.join(default_path, item_name)
                 if os.path.isfile(full_item_path):
-                    script_names.append(item_name[:-4])
+                    script_name_no_ext = item_name[:-4]
+                    
+                    assigned_category = DEFAULT_CATEGORY
+                    for prefix in SCRIPT_PREFIXES:
+                        # We check for "prefix-" or "prefix_" to be more specific than just startswith(prefix)
+                        # to avoid 'http' matching 'httpfoo' if 'httpfoo' isn't a category.
+                        # Or, if a script is named like 'sshnoop.nse', it won't be miscategorized as 'ssh'.
+                        if script_name_no_ext.startswith(prefix + '-') or \
+                           script_name_no_ext.startswith(prefix + '_'):
+                            assigned_category = prefix
+                            break 
+                        # Some scripts might be just the prefix itself e.g. "banner.nse" -> should not be categorized by "ban"
+                        # This is implicitly handled as "banner" would not start with "banner-"
+                    
+                    categorized_scripts.append((assigned_category, script_name_no_ext))
 
-        script_names.sort()
+        categorized_scripts.sort() # Sorts by category (prefix), then by script name
+        
+        # Extract just the script names for the final list
+        final_script_names = [name for category, name in categorized_scripts]
+
     except OSError as e:
         logging.warning(f"Error reading NSE script directory {default_path}: {e}")
-        return []
+        return [] # Return empty list on error
 
-    return script_names
+    return final_script_names
 
 
 def is_root() -> bool:

--- a/src/window.py
+++ b/src/window.py
@@ -44,7 +44,7 @@ class NetworkMapWindow(Adw.ApplicationWindow):
         self._apply_font_preference() # Apply initial font preference
         
         self._connect_signals()
-        # self._populate_nse_script_combo() # This seems to be called later or not needed here
+        self._populate_nse_script_combo() # Ensure NSE scripts are loaded at startup
         self._update_ui_state("ready")
 
     def _apply_font_preference(self) -> None:


### PR DESCRIPTION
Restores the population of the NSE script selection dropdown and enhances it by sorting scripts based on categories derived from common script name prefixes.

Key changes:
- Modified `discover_nse_scripts` in `src/utils.py` to:
  - Categorize scripts by prefixes (e.g., 'http', 'smb', 'dns').
  - Sort scripts first by category, then alphabetically within each category.
  - Return a flat list of script names reflecting this new order.
- Ensured `_populate_nse_script_combo` in `src/window.py` is called during window initialization to populate the `Adw.ComboRow` with the sorted list of scripts (prepending "None").