### PR TITLE
Feat: Add searchable NSE dropdown and live command preview

### DIFF
--- a/src/nmap_scanner.py
+++ b/src/nmap_scanner.py
@@ -61,7 +61,7 @@ class NmapScanner:
                 - An error message string if an error occurred, otherwise None.
         """
         try:
-            scan_args_str = self._build_scan_args(
+            scan_args_str = self.build_scan_args( # Updated call
                 do_os_fingerprint, additional_args_str, nse_script, default_args_str
             )
         except NmapArgumentError as e:
@@ -138,7 +138,7 @@ class NmapScanner:
         # Fallback, though all paths should return before this.
         return None, "Scan failed due to an unexpected internal error."
 
-    def _build_scan_args(
+    def build_scan_args( # Renamed method
         self,
         do_os_fingerprint: bool,
         additional_args_str: str,

--- a/src/window.ui
+++ b/src/window.ui
@@ -65,10 +65,21 @@
                             </child>
                             <child>
                               <object class="AdwComboRow" id="nse_script_combo_row">
-                                <property name="subtitle">Include execution of NSE script</property>
                                 <property name="title">NSE Script</property>
+                                <property name="subtitle">Include execution of NSE script</property>
+                                <property name="enable-search">True</property>
                               </object>
                             </child>
+                          </object>
+                        </child>
+                        <!-- New Adw.EntryRow for Command Preview -->
+                        <child>
+                          <object class="AdwEntryRow" id="nmap_command_preview_row">
+                            <property name="title" translatable="yes">Nmap Command Preview</property>
+                            <property name="subtitle" translatable="yes">Read-only preview of the command to be executed.</property>
+                            <property name="editable">False</property>
+                            <property name="selectable">True</property> 
+                            <property name="activatable">False</property>
                           </object>
                         </child>
                       </object>


### PR DESCRIPTION
Implements two UI enhancements based on your feedback:
1. Makes the Adw.ComboRow for NSE script selection searchable by setting its `enable-search` property to True.
2. Adds a live Nmap command preview:
   - Introduces a new read-only Adw.EntryRow titled "Nmap Command Preview" to the UI.
   - Implements `_update_nmap_command_preview` method in NetworkMapWindow to dynamically build and display the nmap command string based on current UI options and GSettings for default arguments.
   - `NmapScanner._build_scan_args` was made public (`build_scan_args`) to be used by the preview generation logic.
   - Connects relevant signals from all input fields (target, OS fingerprint, additional arguments, NSE script selection) and GSettings (default-nmap-arguments) to ensure the command preview updates in real-time.