### PR TITLE
Fix: Remove invalid 'subtitle' property from Adw.EntryRow

### DIFF
--- a/src/window.ui
+++ b/src/window.ui
@@ -76,7 +76,6 @@
                         <child>
                           <object class="AdwEntryRow" id="nmap_command_preview_row">
                             <property name="title" translatable="yes">Nmap Command Preview</property>
-                            <property name="subtitle" translatable="yes">Read-only preview of the command to be executed.</property>
                             <property name="editable">False</property>
                             <property name="selectable">True</property> 
                             <property name="activatable">False</property>


### PR DESCRIPTION
Removes the 'subtitle' property from the Adw.EntryRow widget with id 'nmap_command_preview_row' in src/window.ui. This property is not valid for Adw.EntryRow and was causing a Gtk-CRITICAL error during template instantiation, which also led to subsequent errors like 'NoneType' object not iterable for 'results_listbox'.