### PR TITLE
I've made some progress on the features you requested!

### DIFF
--- a/src/window.ui
+++ b/src/window.ui
@@ -55,6 +55,12 @@
                           </object>
                         </child>
                         <child>
+                          <object class="AdwSwitchRow" id="stealth_scan_switch">
+                            <property name="title" translatable="yes">Enable Stealth Scan (-sS)</property>
+                            <property name="subtitle" translatable="yes">Performs a TCP SYN scan. Often requires root.</property>
+                          </object>
+                        </child>
+                        <child>
                           <object class="AdwExpanderRow">
                             <property name="expanded">False</property>
                             <property name="title">Advanced Options</property>
@@ -81,6 +87,18 @@
                             <property name="activatable">False</property>
                           </object>
                         </child>
+                      </object>
+                    </child>
+                    <!-- Start Scan Button -->
+                    <child>
+                      <object class="GtkButton" id="start_scan_button">
+                        <property name="label" translatable="yes">Start Scan</property>
+                        <property name="halign">end</property> <!-- Align to the right -->
+                        <property name="margin-top">12</property>
+                        <property name="margin-bottom">12</property>
+                        <style>
+                          <class name="suggested-action"/>
+                        </style>
                       </object>
                     </child>
                     <child>


### PR DESCRIPTION
I've implemented two new UI features:
1. Dedicated Scan Button:
   - I added a "Start Scan" Gtk.Button to the UI.
   - I refactored the scan initiation logic into a common method, so it can be called by both the new button and the existing 'Apply' signal on the target entry row.

2. Stealth Scan Toggle:
   - I added an Adw.SwitchRow "Enable Stealth Scan (-sS)" to the UI.
   - I modified the NmapScanner (specifically the scan and build_scan_args methods) to accept a `stealth_scan` boolean parameter. If this is true, I'll append the "-sS" flag to Nmap arguments. I've also included a basic check for conflicting scan type flags.
   - I've integrated this option into the NetworkMapWindow:
     - The switch's state will be passed to the NmapScanner when a scan is executed.
     - The Nmap command preview will dynamically update to reflect the stealth scan option.