### PR TITLE
Feat: Add Port Spec, Timing Templates, and No-Ping UI options

### DIFF
--- a/src/window.ui
+++ b/src/window.ui
@@ -61,6 +61,12 @@
                           </object>
                         </child>
                         <child>
+                          <object class="AdwSwitchRow" id="no_ping_switch">
+                            <property name="title" translatable="yes">Disable Host Discovery (-Pn)</property>
+                            <property name="subtitle" translatable="yes">Skips host discovery; scans all targets as online.</property>
+                          </object>
+                        </child>
+                        <child>
                           <object class="AdwExpanderRow">
                             <property name="expanded">False</property>
                             <property name="title">Advanced Options</property>
@@ -74,6 +80,18 @@
                                 <property name="title">NSE Script</property>
                                 <property name="subtitle">Include execution of NSE script</property>
                                 <property name="enable-search">True</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="AdwEntryRow" id="port_spec_entry_row">
+                                <property name="title" translatable="yes">Specify Ports</property>
+                                <property name="placeholder-text" translatable="yes">e.g., 80,443 or 1-1024</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="AdwComboRow" id="timing_template_combo_row">
+                                <property name="title" translatable="yes">Timing Template</property>
+                                <!-- The model will be populated from code -->
                               </object>
                             </child>
                           </object>


### PR DESCRIPTION
Integrates new Nmap scanning options into the UI:
1.  Port Specification:
    - Adds an Adw.EntryRow for you to specify target ports (e.g., "80,443", "1-1024").
    - Passes the `-p <ports>` argument to Nmap.
2.  Scan Timing Templates:
    - Adds an Adw.ComboRow to select Nmap timing templates (T0-T5), defaulting to T3.
    - Passes the corresponding `-T<n>` argument to Nmap.
3.  No Ping (-Pn) Toggle:
    - Adds an Adw.SwitchRow to enable/disable host discovery via the `-Pn` Nmap flag.

These options are integrated into both the live Nmap command preview and the actual scan execution logic. NmapScanner methods (scan, build_scan_args) have been updated to accept and process these new parameters.