### PR TITLE
Fix: Remove invalid 'placeholder-text' from Adw.EntryRow

### DIFF
--- a/src/window.ui
+++ b/src/window.ui
@@ -85,7 +85,6 @@
                             <child>
                               <object class="AdwEntryRow" id="port_spec_entry_row">
                                 <property name="title" translatable="yes">Specify Ports</property>
-                                <property name="placeholder-text" translatable="yes">e.g., 80,443 or 1-1024</property>
                               </object>
                             </child>
                             <child>


### PR DESCRIPTION
Removes the 'placeholder-text' property from the Adw.EntryRow widget with id 'port_spec_entry_row' in src/window.ui. This property is not valid for Adw.EntryRow (at least in the version used) and was causing a Gtk-CRITICAL error during template instantiation. This error likely led to subsequent initialization failures, such as 'results_listbox' being None.