### PR TITLE
Fix UI issues in scan configuration

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -216,17 +216,18 @@ class NetworkMapWindow(Adw.ApplicationWindow):
         Handles the selection change in the NSE script combo box.
         Updates `self.selected_nse_script` based on the new selection.
         """
-        selected_index = combo_row.get_selected()
-        model = combo_row.get_model()
+    selected_item = combo_row.get_selected_item() # This gets the Gtk.StringObject
 
-        if isinstance(model, Gtk.StringList) and selected_index >= 0:
-            selected_value = model.get_string(selected_index)
+    if isinstance(selected_item, Gtk.StringObject):
+        selected_value = selected_item.get_string()
             if selected_value == "None":
                 self.selected_nse_script = None
             else:
                 self.selected_nse_script = selected_value
         else:
+        # This case might occur if nothing is selected or model is empty
             self.selected_nse_script = None
+    
         self._update_nmap_command_preview() # Update preview when script changes
 
     def _on_timing_template_selected(self, combo_row: Adw.ComboRow, pspec: GObject.ParamSpec) -> None:
@@ -257,11 +258,15 @@ class NetworkMapWindow(Adw.ApplicationWindow):
             self.target_entry_row.set_sensitive(False)
             self.arguments_entry_row.set_sensitive(False)
             self.os_fingerprint_switch.set_sensitive(False)
+            self.stealth_scan_switch.set_sensitive(False)
+            self.no_ping_switch.set_sensitive(False)
         else:
             self.spinner.set_visible(False)
             self.target_entry_row.set_sensitive(True)
             self.arguments_entry_row.set_sensitive(True)
             self.os_fingerprint_switch.set_sensitive(True)
+            self.stealth_scan_switch.set_sensitive(True)
+            self.no_ping_switch.set_sensitive(True)
 
             if state == "error":
                 self.status_page.set_property(

--- a/src/window.ui
+++ b/src/window.ui
@@ -85,6 +85,7 @@
                             <child>
                               <object class="AdwEntryRow" id="port_spec_entry_row">
                                 <property name="title" translatable="yes">Specify Ports</property>
+                                <property name="placeholder-text" translatable="yes">e.g., 22, 80, 443, 1000-2000</property>
                               </object>
                             </child>
                             <child>


### PR DESCRIPTION
This commit addresses several UI-related issues:

- Ensures the --scripts flag works correctly when an NSE script is selected from the dropdown, even after filtering.
- Disables the -sS (Stealth Scan) and -Pn (No Ping) switches while a scan is in progress, preventing changes to these parameters during active scans.
- Adds placeholder text (e.g., "22, 80, 443, 1000-2000") to the "Specify Ports" entry field to guide you on valid input formats.