### PR TITLE
Fix UI initialization errors

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -52,13 +52,14 @@ class NetworkMapWindow(Adw.ApplicationWindow):
         
         self.settings.connect("changed::results-font", lambda s, k: self._apply_font_preference())
         self.settings.connect("changed::default-nmap-arguments", self._update_nmap_command_preview) # Added
-        self._apply_font_preference() # Apply initial font preference
         
         self._connect_signals()
         self._populate_nse_script_combo() # Ensure NSE scripts are loaded at startup
         self._populate_timing_template_combo() # Populate timing options
         self._update_nmap_command_preview() # Initial command preview
         self._update_ui_state("ready")
+        self.port_spec_entry_row.set_placeholder_text("e.g., 22, 80, 443, 1000-2000")
+        GLib.idle_add(self._apply_font_preference) # Apply initial font preference after UI is fully initialized
 
     def _populate_timing_template_combo(self) -> None:
         """Populates the timing template combo box."""

--- a/src/window.ui
+++ b/src/window.ui
@@ -85,7 +85,6 @@
                             <child>
                               <object class="AdwEntryRow" id="port_spec_entry_row">
                                 <property name="title" translatable="yes">Specify Ports</property>
-                                <property name="placeholder-text" translatable="yes">e.g., 22, 80, 443, 1000-2000</property>
                               </object>
                             </child>
                             <child>


### PR DESCRIPTION
This commit resolves two errors identified from your feedback:

1.  `Invalid property: AdwEntryRow.placeholder-text`: The placeholder text for the "Specify Ports" entry row was being set via the .ui file, which caused an error with the libadwaita version being used. This has been fixed by removing the property from the .ui file and setting it programmatically in `src/window.py` using `self.port_spec_entry_row.set_placeholder_text()`.

2.  `TypeError: 'NoneType' object is not iterable` for `self.results_listbox`: This occurred because `_apply_font_preference` was called in `__init__` before `self.results_listbox` (a Gtk.Template.Child) was fully initialized. The fix defers the call to `_apply_font_preference` using `GLib.idle_add()`, ensuring it runs after the UI is ready.

These changes should lead to a more stable UI initialization.