### PR TITLE
Fix AttributeError for Adw.EntryRow placeholder-text

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -58,7 +58,7 @@ class NetworkMapWindow(Adw.ApplicationWindow):
         self._populate_timing_template_combo() # Populate timing options
         self._update_nmap_command_preview() # Initial command preview
         self._update_ui_state("ready")
-        self.port_spec_entry_row.set_placeholder_text("e.g., 22, 80, 443, 1000-2000")
+        self.port_spec_entry_row.props.placeholder_text = "e.g., 22, 80, 443, 1000-2000"
         GLib.idle_add(self._apply_font_preference) # Apply initial font preference after UI is fully initialized
 
     def _populate_timing_template_combo(self) -> None:


### PR DESCRIPTION
This commit resolves an `AttributeError` that occurred when you were trying to set the placeholder text for the `Adw.EntryRow` (port_spec_entry_row) using a non-existent `set_placeholder_text()` method.

The fix changes the line:
`self.port_spec_entry_row.set_placeholder_text(...)` to:
`self.port_spec_entry_row.props.placeholder_text = ...` This uses the GObject property access mechanism, which is the correct way to set the `placeholder-text` property on an Adw.EntryRow programmatically.

This is a follow-up to previous fixes for UI initialization:
- Addressing "Invalid property: AdwEntryRow.placeholder-text" from .ui.
- Fixing a TypeError for `self.results_listbox` during font application.