### PR TITLE
Fix AttributeError for Adw.EntryRow placeholder-text (again)

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -58,7 +58,7 @@ class NetworkMapWindow(Adw.ApplicationWindow):
         self._populate_timing_template_combo() # Populate timing options
         self._update_nmap_command_preview() # Initial command preview
         self._update_ui_state("ready")
-        self.port_spec_entry_row.props.placeholder_text = "e.g., 22, 80, 443, 1000-2000"
+        self.port_spec_entry_row.set_property("placeholder-text", "e.g., 22, 80, 443, 1000-2000")
         GLib.idle_add(self._apply_font_preference) # Apply initial font preference after UI is fully initialized
 
     def _populate_timing_template_combo(self) -> None:


### PR DESCRIPTION
This commit resolves an `AttributeError: 'gi._gi.GProps' object has no attribute 'placeholder_text'` that occurred when trying to set the placeholder text for `Adw.EntryRow` (port_spec_entry_row).

The fix changes the line:
`self.port_spec_entry_row.props.placeholder_text = ...` to:
`self.port_spec_entry_row.set_property("placeholder-text", ...)`

This uses the generic `set_property` method, which is the correct way to set a GObject property when direct attribute access on `props` is not available or the property name is not a direct attribute of the `props` object.

This is a follow-up to previous fixes for UI initialization, including attempts to set this same placeholder text.