### PR TITLE
Remove problematic placeholder-text setting for Adw.EntryRow

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -58,7 +58,6 @@ class NetworkMapWindow(Adw.ApplicationWindow):
         self._populate_timing_template_combo() # Populate timing options
         self._update_nmap_command_preview() # Initial command preview
         self._update_ui_state("ready")
-        self.port_spec_entry_row.set_property("placeholder-text", "e.g., 22, 80, 443, 1000-2000")
         GLib.idle_add(self._apply_font_preference) # Apply initial font preference after UI is fully initialized
 
     def _populate_timing_template_combo(self) -> None:


### PR DESCRIPTION
This commit removes the line that attempted to set the `placeholder-text` property on the `port_spec_entry_row` (an Adw.EntryRow) in `src/window.py`.

Multiple attempts to set this property (via .ui file, `props.placeholder_text`, and `set_property("placeholder-text", ...)`) have resulted in runtime errors, indicating that the `placeholder-text` property is not available or usable on `Adw.EntryRow` in the specific libadwaita version/environment being used.

While this means the "Specify Ports" field will not have an example placeholder, removing this line is necessary to prevent the application from crashing on startup. The original UI issues concerning script selection and switch sensitivity should still be resolved by earlier commits in this branch.