### PR TITLE
Fix TypeError for EntryCompletion and update meson.build

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -31,10 +31,12 @@ configure_file(
 networkmap_sources = [
   '__init__.py',
   'main.py',
-  'window.py',
   'nmap_scanner.py',
   'preferences_window.py',
+  'profile_editor_dialog.py',
+  'profile_manager.py',
   'utils.py',
+  'window.py',
 ]
 
 py_installation.install_sources(

--- a/src/window.py
+++ b/src/window.py
@@ -64,9 +64,13 @@ class NetworkMapWindow(Adw.ApplicationWindow):
         self.settings.connect(f"changed::{self.TARGET_HISTORY_SCHEMA_KEY}", self._on_target_history_changed)
 
         # Target history completion setup
-        self.target_completion_model = Gtk.StringList.new(self.target_history_list)
+        self.target_completion_model = Gtk.ListStore(str)
+        for target_str in self.target_history_list:
+            self.target_completion_model.append([target_str])
+        
         self.target_completion = Gtk.EntryCompletion()
         self.target_completion.set_model(self.target_completion_model)
+        self.target_completion.set_text_column(0) # Specify column for Gtk.ListStore
         self.target_completion.set_inline_completion(True)
         self.target_completion.set_popup_completion(True)
         self.target_entry_row.set_completion(self.target_completion)
@@ -459,9 +463,10 @@ class NetworkMapWindow(Adw.ApplicationWindow):
         # print("DEBUG: Target history GSetting changed, updating completion model.")
         self.target_history_list = list(self.settings.get_strv(key_name)) 
         
-        new_model = Gtk.StringList.new(self.target_history_list)
-        self.target_completion_model = new_model 
-        self.target_completion.set_model(self.target_completion_model)
+        self.target_completion_model.clear()
+        for target_str in self.target_history_list:
+            self.target_completion_model.append([target_str])
+        # No need to call self.target_completion.set_model() again, as the model object itself was modified.
 
     def _initiate_scan_procedure(self) -> None:
         """Core logic to start an Nmap scan based on current UI settings."""


### PR DESCRIPTION
This commit addresses two issues:

1.  **TypeError with Gtk.EntryCompletion Model:**
    - Changed the model for target history autofill (`self.target_completion_model` in `src/window.py`) from `Gtk.StringList` to `Gtk.ListStore(str)`.
    - `Gtk.EntryCompletion` requires a `Gtk.TreeModel`, and `Gtk.ListStore` fulfills this requirement.
    - Added `set_text_column(0)` for the completion view.
    - Updated model population and refresh logic accordingly.

2.  **Update src/meson.build:**
    - Added `profile_manager.py` and `profile_editor_dialog.py` to the `networkmap_sources` list in `src/meson.build` to ensure they are installed with the application.

These changes should resolve the runtime TypeError and ensure all necessary source files are included in the build.