### PR TITLE
Fix AttributeError for Adw.EntryRow completion property

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -73,7 +73,7 @@ class NetworkMapWindow(Adw.ApplicationWindow):
         self.target_completion.set_text_column(0) # Specify column for Gtk.ListStore
         self.target_completion.set_inline_completion(True)
         self.target_completion.set_popup_completion(True)
-        self.target_entry_row.set_completion(self.target_completion)
+        self.target_entry_row.set_property("completion", self.target_completion)
         
         self._connect_signals() # Original signals
         


### PR DESCRIPTION
This commit resolves an `AttributeError: 'EntryRow' object has no attribute 'set_completion'`.

The `completion` on an `Adw.EntryRow` is a GObject property, not set via a direct setter method of that name. The fix changes the line: `self.target_entry_row.set_completion(self.target_completion)` to:
`self.target_entry_row.set_property("completion", self.target_completion)`

This ensures the Gtk.EntryCompletion object is correctly assigned to the Adw.EntryRow for target input autofill. This is a follow-up to previous fixes for TypeError on the completion model and meson.build updates.