### PR TITLE
fix: Correct Adw.Dialog initialization in ProfileEditorDialog

### DIFF
--- a/src/profile_editor_dialog.py
+++ b/src/profile_editor_dialog.py
@@ -4,7 +4,10 @@ from .profile_manager import ScanProfile # Assuming ScanProfile is in profile_ma
 
 class ProfileEditorDialog(Adw.Dialog):
     def __init__(self, parent_window: Gtk.Window, profile_to_edit: Optional[ScanProfile] = None, existing_profile_names: Optional[List[str]] = None):
-        super().__init__(transient_for=parent_window, modal=True)
+        super().__init__() # Changed line
+        if parent_window:
+            self.set_transient_for(parent_window)
+        self.set_modal(True)
 
         self.profile_to_edit = profile_to_edit
         self.is_editing = profile_to_edit is not None


### PR DESCRIPTION
Resolves a TypeError: "gobject ... doesn't support property 'transient_for'".

The `transient_for` and `modal` properties for Adw.Dialog (which ProfileEditorDialog inherits from) should be set using their respective setter methods (`set_transient_for()`, `set_modal()`) after the `super().__init__()` call, rather than as constructor arguments.

This commit updates the `__init__` method in
`src/profile_editor_dialog.py` to initialize Adw.Dialog correctly.