### PR TITLE
fix: Use set_property for Adw.Dialog transient-for and modal

### DIFF
--- a/src/profile_editor_dialog.py
+++ b/src/profile_editor_dialog.py
@@ -4,10 +4,11 @@ from .profile_manager import ScanProfile # Assuming ScanProfile is in profile_ma
 
 class ProfileEditorDialog(Adw.Dialog):
     def __init__(self, parent_window: Gtk.Window, profile_to_edit: Optional[ScanProfile] = None, existing_profile_names: Optional[List[str]] = None):
-        super().__init__() # Changed line
+        super().__init__() 
+            
         if parent_window:
-            self.set_transient_for(parent_window)
-        self.set_modal(True)
+            self.set_property("transient-for", parent_window) # Changed line
+        self.set_property("modal", True) # Changed line
 
         self.profile_to_edit = profile_to_edit
         self.is_editing = profile_to_edit is not None


### PR DESCRIPTION
This commit resolves an `AttributeError` that occurred when trying to set the `transient-for` and `modal` behaviors for `ProfileEditorDialog` (an Adw.Dialog subclass).

Previous attempts using direct setter methods (`set_transient_for()`) or passing them as constructor keyword arguments to `super().__init__()` failed.

The fix now uses the generic GObject `set_property()` method:
- `self.set_property("transient-for", parent_window)`
- `self.set_property("modal", True)`

This is the standard way to set GObject properties if specific setters or constructor arguments are not available or not working as expected for the particular widget version.