### PR TITLE
Here's the plan:

### DIFF
--- a/src/preferences_window.py
+++ b/src/preferences_window.py
@@ -64,7 +64,6 @@ class NetworkMapPreferencesWindow(Adw.PreferencesWindow):
         self._load_and_display_profiles()
 
     def _load_and_display_profiles(self) -> None:
-        # Clear existing rows
         while child := self.profiles_list_box.get_row_at_index(0):
             self.profiles_list_box.remove(child)
 
@@ -72,18 +71,18 @@ class NetworkMapPreferencesWindow(Adw.PreferencesWindow):
         for profile in profiles:
             row = Adw.ActionRow()
             row.set_title(profile['name'])
-            row.set_activatable(False) # So clicking the row itself does nothing
+            row.set_activatable(False)
 
             button_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
             
-            edit_button = Gtk.Button(icon_name="document-edit-symbolic") # Using icon instead of text
+            edit_button = Gtk.Button(icon_name="document-edit-symbolic")
             edit_button.add_css_class("flat")
             # The signal connection needs to pass the profile name (or full profile object)
             # Using functools.partial or a lambda:
             edit_button.connect("clicked", lambda b, p_name=profile['name']: self._on_edit_profile_clicked(b, p_name))
             button_box.append(edit_button)
 
-            delete_button = Gtk.Button(icon_name="edit-delete-symbolic") # Using icon
+            delete_button = Gtk.Button(icon_name="edit-delete-symbolic")
             delete_button.add_css_class("flat")
             delete_button.add_css_class("destructive-action")
             delete_button.connect("clicked", lambda b, p_name=profile['name']: self._on_delete_profile_clicked(b, p_name))
@@ -137,7 +136,7 @@ class NetworkMapPreferencesWindow(Adw.PreferencesWindow):
             # More advanced: could show a Adw.Toast on the main window if a reference is passed.
         else:
             print(f"Failed to delete profile '{profile_name}'.")
-        self._load_and_display_profiles() # Refresh the list
+        self._load_and_display_profiles()
 
     def _on_font_changed(self, font_button: Gtk.FontButton) -> None:
         """

--- a/src/profile_editor_dialog.py
+++ b/src/profile_editor_dialog.py
@@ -1,14 +1,14 @@
 from gi.repository import Adw, Gtk
-from typing import Optional, Dict, List # Ensure List is imported
-from .profile_manager import ScanProfile # Assuming ScanProfile is in profile_manager
+from typing import Optional, Dict, List
+from .profile_manager import ScanProfile
 
 class ProfileEditorDialog(Adw.Dialog):
     def __init__(self, parent_window: Gtk.Window, profile_to_edit: Optional[ScanProfile] = None, existing_profile_names: Optional[List[str]] = None):
         super().__init__() 
             
         if parent_window:
-            self.set_property("transient-for", parent_window) # Changed line
-        self.set_property("modal", True) # Changed line
+            self.set_transient_for(parent_window)
+        self.set_modal(True)
 
         self.profile_to_edit = profile_to_edit
         self.is_editing = profile_to_edit is not None
@@ -19,20 +19,17 @@ class ProfileEditorDialog(Adw.Dialog):
 
 
         self.set_title("Edit Profile" if self.is_editing else "Add New Profile")
-        # self.set_default_size(400, -1) # Adjust as needed
 
         content_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
         content_box.set_margin_top(12)
         content_box.set_margin_bottom(12)
         content_box.set_margin_start(12)
         content_box.set_margin_end(12)
-        self.set_child(content_box) # For Adw.Dialog, use set_child
+        self.set_child(content_box)
 
-        # Profile Name
         self.name_row = Adw.EntryRow(title="Profile Name")
         content_box.append(self.name_row)
 
-        # Switches
         self.os_fingerprint_switch = Adw.SwitchRow(title="OS Fingerprinting")
         content_box.append(self.os_fingerprint_switch)
         self.stealth_scan_switch = Adw.SwitchRow(title="Enable Stealth Scan (-sS)")
@@ -40,29 +37,25 @@ class ProfileEditorDialog(Adw.Dialog):
         self.no_ping_switch = Adw.SwitchRow(title="Disable Host Discovery (-Pn)")
         content_box.append(self.no_ping_switch)
 
-        # Port Specification
         self.ports_row = Adw.EntryRow(title="Specify Ports")
         content_box.append(self.ports_row)
 
         # NSE Script
-        self.nse_script_row = Adw.EntryRow(title="NSE Script") # Simple text entry for now
+        self.nse_script_row = Adw.EntryRow(title="NSE Script")
         content_box.append(self.nse_script_row)
         
-        # Timing Template (Adw.ComboRow)
         self.timing_options: Dict[str, Optional[str]] = {
             "Default (T3)": None, "Paranoid (T0)": "-T0", "Sneaky (T1)": "-T1",
             "Polite (T2)": "-T2", "Aggressive (T4)": "-T4", "Insane (T5)": "-T5",
         }
         timing_model = Gtk.StringList.new(list(self.timing_options.keys()))
         self.timing_combo_row = Adw.ComboRow(title="Timing Template", model=timing_model)
-        self.timing_combo_row.set_selected(0) # Default
+        self.timing_combo_row.set_selected(0)
         content_box.append(self.timing_combo_row)
 
-        # Additional Arguments
         self.additional_args_row = Adw.EntryRow(title="Additional Arguments")
         content_box.append(self.additional_args_row)
         
-        # Populate fields if editing
         if self.is_editing and self.profile_to_edit:
             self.name_row.set_text(self.profile_to_edit['name'])
             self.os_fingerprint_switch.set_active(self.profile_to_edit['os_fingerprint'])
@@ -72,27 +65,19 @@ class ProfileEditorDialog(Adw.Dialog):
             self.nse_script_row.set_text(self.profile_to_edit['nse_script'])
             self.additional_args_row.set_text(self.profile_to_edit['additional_args'])
             
-            # Set timing template
             selected_timing_arg = self.profile_to_edit['timing_template']
-            selected_idx = 0 # Default
+            selected_idx = 0
             for i, (display_name, arg_val) in enumerate(self.timing_options.items()):
                 if arg_val == selected_timing_arg:
                     selected_idx = i
                     break
             self.timing_combo_row.set_selected(selected_idx)
 
-        # Add response buttons
         self.add_response("cancel", "Cancel")
         self.add_response("save", "Save")
         self.set_response_appearance("save", Adw.ResponseAppearance.SUGGESTED)
         self.set_default_response("save") 
         self.connect("response", self._on_response)
-        
-        # For validation feedback
-        self.toast_overlay = Adw.ToastOverlay()
-        # Adw.Dialog doesn't have a direct child like Adw.Window for toast overlay
-        # Instead, we might need to show toasts on the parent window or handle validation differently
-        # For now, let's skip direct toast overlay in dialog, validation can be simpler.
 
 
     def _on_response(self, dialog, response_id: str):
@@ -107,7 +92,6 @@ class ProfileEditorDialog(Adw.Dialog):
         profile_name = self.name_row.get_text().strip()
         if not profile_name:
             # Show some validation error - e.g. by returning None and letting caller handle
-            # Or, if toast_overlay was available: self.toast_overlay.add_toast(Adw.Toast.new("Profile name cannot be empty!"))
             print("Error: Profile name cannot be empty.")
             return None
         


### PR DESCRIPTION
1.  **Fix TypeError in ProfileEditorDialog**: I'll address the TypeError that occurs when you try to add a new profile in the preferences window. This involves changing how "transient-for" and "modal" properties are set on Adw.Dialog, using the correct setter methods inherited from Gtk.Window.
2.  **Refactor comments**: I'll improve the comments in `profile_editor_dialog.py` and `preferences_window.py` by removing redundant or unhelpful ones and enhancing clarity. I'll also remove commented-out, non-functional code related to a toast overlay in the dialog.