### PR TITLE
Fix TypeError for Adw.Dialog parenting and modality

### DIFF
--- a/src/preferences_window.py
+++ b/src/preferences_window.py
@@ -104,7 +104,7 @@ class NetworkMapPreferencesWindow(Adw.PreferencesWindow):
             d.close() 
         
         dialog.connect("response", on_dialog_response)
-        dialog.present()
+        dialog.present(self)
 
     def _on_edit_profile_clicked(self, button: Gtk.Button, profile_name: str) -> None:
         profile_to_edit = next((p for p in self.profile_manager.load_profiles() if p['name'] == profile_name), None)
@@ -123,7 +123,7 @@ class NetworkMapPreferencesWindow(Adw.PreferencesWindow):
                 d.close()
 
             dialog.connect("response", on_dialog_response)
-            dialog.present()
+            dialog.present(self)
         else:
             print(f"Error: Could not find profile '{profile_name}' to edit.")
 

--- a/src/profile_editor_dialog.py
+++ b/src/profile_editor_dialog.py
@@ -6,10 +6,6 @@ class ProfileEditorDialog(Adw.Dialog):
     def __init__(self, parent_window: Gtk.Window, profile_to_edit: Optional[ScanProfile] = None, existing_profile_names: Optional[List[str]] = None):
         super().__init__() 
             
-        if parent_window:
-            self.set_transient_for(parent_window)
-        self.set_modal(True)
-
         self.profile_to_edit = profile_to_edit
         self.is_editing = profile_to_edit is not None
         self.existing_profile_names = existing_profile_names or []


### PR DESCRIPTION
Corrects the approach for showing an Adw.Dialog and setting it up with its parent window. The original TypeError indicated that the 'transient-for' property was not found on ProfileEditorDialog (an Adw.Dialog).

Removed explicit attempts to set 'transient-for' and 'modal' properties on the Adw.Dialog instance within its `__init__` method. Instead, updated the dialog presentation calls in
NetworkMapPreferencesWindow to use `dialog.present(self)`. This uses the Adw.Dialog's specific present method, which takes the parent window as an argument and is the recommended way to handle dialog presentation and parenting in libadwaita.

This change relies on Adw.Dialog's presentation logic to correctly handle transiency and modality.