### PR TITLE
Fix NameError by adding missing Optional import

### DIFF
--- a/src/preferences_window.py
+++ b/src/preferences_window.py
@@ -1,4 +1,5 @@
 from gi.repository import Adw, Gtk, GObject, Gio, Pango
+from typing import Optional
 
 from .utils import apply_theme
 from .profile_manager import ProfileManager, ScanProfile


### PR DESCRIPTION
Adds `from typing import Optional` to `src/preferences_window.py`. This was missing and caused a `NameError: name 'Optional' is not defined` when the type hints for the new profile dialog action handlers were evaluated.