### PR TITLE
Phase 2: Implement Profile Import and Export Functionality

### DIFF
--- a/src/preferences_window.py
+++ b/src/preferences_window.py
@@ -65,7 +65,123 @@ class NetworkMapPreferencesWindow(Adw.PreferencesWindow):
 
         self.profile_manager = ProfileManager()
         self.add_profile_button.connect("clicked", self._on_add_profile_clicked)
+        
+        # Setup for Export Profiles Button
+        # Assuming profiles_list_box and add_profile_button are within the same Adw.PreferencesGroup
+        # We'll add a new ActionRow for the export button within that group.
+        
+        # Create the export button
+        self.export_profiles_button = Gtk.Button(label="Export All...", halign=Gtk.Align.CENTER) # Centered for a full row button
+        self.export_profiles_button.connect("clicked", self._on_export_profiles_clicked)
+        
+        # Create an ActionRow for the export button
+        # Using title to make it look like other preference rows, but button does the action
+        export_action_row = Adw.ActionRow() 
+        # export_action_row.set_title("Profile Management") # Optional: Title for the row
+        export_action_row.set_activatable_widget(self.export_profiles_button)
+        export_action_row.add_suffix(self.export_profiles_button) # Button on the side
+        # Or, for a button that spans more centrally:
+        # export_action_row.set_child(self.export_profiles_button) # This makes button fill the row if not using suffix/prefix
+
+        # Attempt to find the parent Adw.PreferencesGroup to add the new ActionRow
+        # This logic assumes a structure like: Adw.PreferencesPage -> Adw.PreferencesGroup -> [profiles_list_box, add_profile_button_row, etc.]
+        parent_group = None
+        widget = self.profiles_list_box
+        # Traverse up to find an Adw.PreferencesGroup or Adw.PreferencesPage (which can also hold rows)
+        for _ in range(5): # Limit search depth
+            if widget:
+                parent = widget.get_parent()
+                if isinstance(parent, (Adw.PreferencesGroup, Adw.PreferencesPage)):
+                    parent_group = parent
+                    break
+                widget = parent
+            else:
+                break
+        
+        if parent_group:
+            parent_group.add(export_action_row)
+            
+            # Add Import Profiles button and its ActionRow to the same parent_group
+            import_action_row = Adw.ActionRow(title="Import Profiles from File") # Title for clarity
+            self.import_profiles_button = Gtk.Button(label="Import...", halign=Gtk.Align.END)
+            self.import_profiles_button.connect("clicked", self._on_import_profiles_clicked)
+            import_action_row.add_suffix(self.import_profiles_button)
+            import_action_row.set_activatable_widget(self.import_profiles_button)
+            parent_group.add(import_action_row) # Add to the same group as export
+        else:
+            # Fallback: if no suitable group found, this might indicate unexpected UI structure
+            # For now, log and the button won't be added. Robust solution may need specific group ID from UI.
+            print("Warning: Could not find a suitable Adw.PreferencesGroup to add 'Export Profiles' or 'Import Profiles' button.")
+
         self._load_and_display_profiles()
+
+    def _on_import_profiles_clicked(self, button: Gtk.Button) -> None:
+        file_chooser = Gtk.FileChooserNative.new(
+            title="Import Profiles",
+            parent=self.get_root(), # Get the top-level window
+            action=Gtk.FileChooserAction.OPEN,
+            accept_label="_Open",
+            cancel_label="_Cancel"
+        )
+       
+        json_filter = Gtk.FileFilter()
+        json_filter.set_name("JSON files")
+        json_filter.add_mime_type("application/json")
+        file_chooser.add_filter(json_filter)
+       
+        file_chooser.connect("response", self._on_import_file_chooser_response)
+        file_chooser.show()
+
+    def _on_import_file_chooser_response(self, dialog: Gtk.FileChooserNative, response_id: int) -> None:
+        if response_id == Gtk.ResponseType.ACCEPT:
+            file_obj = dialog.get_file() # Gio.File object
+            if file_obj:
+                filepath = file_obj.get_path()
+                try:
+                    imported_count, skipped_count = self.profile_manager.import_profiles_from_file(filepath)
+                    toast_message = f"Imported {imported_count} profiles."
+                    if skipped_count > 0:
+                        toast_message += f" Skipped {skipped_count} duplicates or invalid entries."
+                    self.add_toast(Adw.Toast.new(toast_message))
+                    self._load_and_display_profiles() # Refresh the list
+                except ProfileStorageError as e:
+                    self.add_toast(Adw.Toast.new(f"Error importing profiles: {e}"))
+                except Exception as e:
+                    self.add_toast(Adw.Toast.new(f"An unexpected error occurred during import: {e}"))
+        dialog.destroy() # Important to destroy the native dialog
+
+    def _on_export_profiles_clicked(self, button: Gtk.Button) -> None:
+        file_chooser = Gtk.FileChooserNative.new(
+            title="Export Profiles",
+            parent=self.get_root(), # Get the top-level window
+            action=Gtk.FileChooserAction.SAVE,
+            accept_label="_Save",
+            cancel_label="_Cancel"
+        )
+       
+        file_chooser.set_current_name("networkmap_profiles.json")
+
+        json_filter = Gtk.FileFilter()
+        json_filter.set_name("JSON files")
+        json_filter.add_mime_type("application/json") # Corrected: add_mime_type
+        file_chooser.add_filter(json_filter)
+
+        file_chooser.connect("response", self._on_export_file_chooser_response)
+        file_chooser.show()
+
+    def _on_export_file_chooser_response(self, dialog: Gtk.FileChooserNative, response_id: int) -> None:
+        if response_id == Gtk.ResponseType.ACCEPT:
+            file_obj = dialog.get_file() # Gio.File object
+            if file_obj:
+                filepath = file_obj.get_path()
+                try:
+                    self.profile_manager.export_profiles_to_file(filepath)
+                    self.add_toast(Adw.Toast.new(f"Profiles exported successfully to {filepath}"))
+                except ProfileStorageError as e:
+                    self.add_toast(Adw.Toast.new(f"Error exporting profiles: {e}"))
+                except Exception as e: # Catch any other unexpected errors
+                    self.add_toast(Adw.Toast.new(f"An unexpected error occurred during export: {e}"))
+        dialog.destroy() # Important to destroy the native dialog
 
     def _load_and_display_profiles(self) -> None:
         # Clear existing rows first


### PR DESCRIPTION
This commit introduces features to allow you to import and export your scan profiles, enhancing profile management capabilities.

Key changes:

- **ProfileManager (`src/profile_manager.py`):**
    - Added `export_profiles_to_file(filepath)`: Serializes all current profiles to a JSON file at the given path. Handles potential file I/O and serialization errors by raising `ProfileStorageError`.
    - Added `import_profiles_from_file(filepath)`: Reads profiles from a JSON file. It skips importing profiles if a profile with the same name already exists. It validates the basic structure of imported data and provides default values for missing optional fields in `ScanProfile`. Returns a tuple `(imported_count, skipped_count)`. Handles file I/O, JSON parsing, and data validation errors, raising `ProfileStorageError` for critical issues.
    - Ensured `Tuple` is imported from `typing`.

- **NetworkMapPreferencesWindow (`src/preferences_window.py`):**
    - **Export UI:** - Added an "Export All..." button to the preferences UI. - Implemented a click handler that uses `Gtk.FileChooserNative` to allow you to select a save location and filename. - Calls `profile_manager.export_profiles_to_file()` and provides user feedback via `Adw.Toast` for success or errors.
    - **Import UI:**
        - Added an "Import Profiles..." button to the preferences UI, placed consistently with the export button.
        - Implemented a click handler that uses `Gtk.FileChooserNative` for selecting a JSON file to import. - Calls `profile_manager.import_profiles_from_file()` and displays results (imported/skipped counts) or errors using `Adw.Toast`. - Refreshes the profile list in the UI after a successful import.

The "Profile Reordering" feature, also part of the original Phase 2, has been deferred due to its implementation complexity in the current interaction model and will be addressed separately.