### PR TITLE
Phase 3: Enhanced NSE Script Handling

### DIFF
--- a/src/nse_script_selection_dialog.py
+++ b/src/nse_script_selection_dialog.py
@@ -1,0 +1,116 @@
+from gi.repository import Adw, Gtk, GObject
+from typing import List, Optional
+
+# A predefined list of common NSE scripts with a display name and script name
+# (display_name, script_name_for_nmap)
+PREDEFINED_NSE_SCRIPTS = [
+    ("HTTP Service and Page Title", "http-title"),
+    ("Banner Grabbing", "banner"),
+    ("SMB OS Discovery", "smb-os-discovery"),
+    ("SSH Host Key Information", "ssh-hostkey"),
+    ("DNS Brute Force Resolver", "dns-brute"),
+    ("SSL/TLS Cipher Suites", "ssl-enum-ciphers"),
+    ("Vulnerability Scan (Vulners)", "vulners"),
+    ("Default HTTP Login Enumerator", "http-default-accounts"),
+    ("FTP Allowed Anonymous Login", "ftp-anon"),
+    ("SMB Shares Enumeration", "smb-enum-shares")
+]
+
+class NseScriptSelectionDialog(Adw.Dialog):
+    __gsignals__ = {
+        'scripts-selected': (GObject.SignalFlags.RUN_FIRST, None, (str,))
+    }
+
+    def __init__(self, parent_window: Gtk.Window, current_scripts_str: Optional[str] = None):
+        # super().__init__(transient_for=parent_window, modal=True) # Adw.Dialog doesn't take these in constructor
+                                                                  # We set them after super if needed,
+                                                                  # but for Adw.Dialog, present(parent) handles transiency
+                                                                  # and they are modal by nature.
+                                                                  # Let's remove these from super() call for Adw.Dialog.
+        # super().__init__() # Correct for Adw.Dialog that doesn't take these in constructor.
+        # Actually, Adw.Dialog can take transient_for and modal in its PyGObject constructor
+        # Let's stick to what works for Adw.Dialog based on PyGObject bindings.
+        # The most reliable for Adw.Dialog is often to set them after if not using a .ui file.
+        # However, for this task, let's assume the simpler Adw.Dialog constructor without explicit parent/modal here,
+        # as it will be presented modally via profile_editor_dialog.
+
+        super().__init__() # Simplest Adw.Dialog constructor
+        if parent_window:
+             self.set_transient_for(parent_window) # Standard GTK Window method
+        self.set_modal(True) # Standard GTK Window method
+
+
+        self.set_title("Select NSE Scripts")
+        self.set_default_size(500, 400)
+
+        self.current_selected_scripts = set(s.strip() for s in current_scripts_str.split(',') if s.strip()) if current_scripts_str else set()
+
+        main_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        main_box.set_margin_top(12)
+        main_box.set_margin_bottom(12)
+        main_box.set_margin_start(12)
+        main_box.set_margin_end(12)
+        self.set_child(main_box) # For Adw.Dialog
+
+        # Scrolled Window for script list
+        scrolled_window = Gtk.ScrolledWindow()
+        scrolled_window.set_has_frame(True)
+        scrolled_window.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        scrolled_window.set_vexpand(True)
+        main_box.append(scrolled_window)
+
+        self.list_box = Gtk.ListBox()
+        self.list_box.set_selection_mode(Gtk.SelectionMode.NONE)
+        scrolled_window.set_child(self.list_box)
+
+        self.check_buttons = {} # To store script_name: Gtk.CheckButton
+
+        for display_name, script_name in PREDEFINED_NSE_SCRIPTS:
+            row = Adw.ActionRow(title=display_name)
+            check_button = Gtk.CheckButton()
+            check_button.set_active(script_name in self.current_selected_scripts)
+            # Store a reference or the script name with the check_button
+            self.check_buttons[script_name] = check_button
+            
+            row.add_suffix(check_button)
+            row.set_activatable_widget(check_button) # Click row to toggle checkbutton
+            self.list_box.append(row)
+
+        # Action buttons
+        action_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6, halign=Gtk.Align.END)
+        action_box.set_margin_top(12)
+        
+        self.cancel_button = Gtk.Button(label="Cancel")
+        self.cancel_button.connect("clicked", self._on_cancel_clicked)
+        action_box.append(self.cancel_button)
+
+        self.select_button = Gtk.Button(label="Select")
+        self.select_button.add_css_class("suggested-action")
+        self.select_button.connect("clicked", self._on_select_clicked)
+        action_box.append(self.select_button)
+        
+        main_box.append(action_box)
+
+    def _on_cancel_clicked(self, button: Gtk.Button):
+        self.close()
+
+    def _on_select_clicked(self, button: Gtk.Button):
+        selected_scripts_list = []
+        for script_name, check_button in self.check_buttons.items():
+            if check_button.get_active():
+                selected_scripts_list.append(script_name)
+        
+        # (Optional: If an EntryRow for custom scripts was added, append its content too)
+        # custom_scripts = self.custom_script_entry.get_text().strip()
+        # if custom_scripts:
+        #    selected_scripts_list.extend([s.strip() for s in custom_scripts.split(',') if s.strip()])
+
+        # Remove duplicates that might arise if custom entry duplicated a checked one
+        # final_scripts_set = set(selected_scripts_list) 
+        # final_scripts_str = ",".join(sorted(list(final_scripts_set))) # Sorted for consistency
+
+        final_scripts_str = ",".join(sorted(selected_scripts_list))
+
+
+        self.emit("scripts-selected", final_scripts_str)
+        self.close()

--- a/src/profile_editor_dialog.py
+++ b/src/profile_editor_dialog.py
@@ -1,6 +1,7 @@
 from gi.repository import Adw, Gtk, GObject
 from typing import Optional, Dict, List
 from .profile_manager import ScanProfile
+from .nse_script_selection_dialog import NseScriptSelectionDialog
 
 class ProfileEditorDialog(Adw.Dialog):
     __gsignals__ = {
@@ -48,6 +49,13 @@ class ProfileEditorDialog(Adw.Dialog):
 
         # NSE Script
         self.nse_script_row = Adw.EntryRow(title="NSE Script")
+        # Create the "Select Scripts..." button
+        self.select_nse_scripts_button = Gtk.Button(label="Select...")
+        self.select_nse_scripts_button.set_tooltip_text("Select NSE Scripts or enter manually")
+        # Add button as suffix to nse_script_row
+        self.nse_script_row.add_suffix(self.select_nse_scripts_button)
+        # Connect the button's "clicked" signal
+        self.select_nse_scripts_button.connect("clicked", self._on_select_nse_scripts_clicked)
         content_box.append(self.nse_script_row)
         
         self.timing_options: Dict[str, Optional[str]] = {
@@ -135,3 +143,14 @@ class ProfileEditorDialog(Adw.Dialog):
             timing_template=timing_template_val if timing_template_val else "", # Ensure empty string not None for consistency
             additional_args=self.additional_args_row.get_text()
         )
+
+    def _on_select_nse_scripts_clicked(self, button: Gtk.Button) -> None:
+        current_scripts = self.nse_script_row.get_text()
+        # Pass `self` as the parent_window for the dialog
+        script_dialog = NseScriptSelectionDialog(parent_window=self, current_scripts_str=current_scripts)
+        
+        script_dialog.connect("scripts-selected", self._on_nse_scripts_selected_from_dialog)
+        script_dialog.present() 
+
+    def _on_nse_scripts_selected_from_dialog(self, dialog_instance, selected_scripts_string: str) -> None:
+        self.nse_script_row.set_text(selected_scripts_string)


### PR DESCRIPTION
This commit introduces an improved UI for selecting NSE (Nmap Scripting Engine) scripts within the Profile Editor.

Key changes:

- **New `NseScriptSelectionDialog` (`src/nse_script_selection_dialog.py`):**
    - I created a new dialog (`Adw.Dialog`) that allows you to select from a predefined list of common and useful NSE scripts.
    - Each script is presented with a checkable widget (`Adw.ActionRow` with a `Gtk.CheckButton`).
    - The dialog takes the current script string as input to pre-select items.
    - On confirmation, it emits a `scripts-selected` GObject signal with a comma-separated string of the chosen script names.

- **Integration into `ProfileEditorDialog` (`src/profile_editor_dialog.py`):**
    - The `Adw.EntryRow` for NSE script input now has a "Select..." button as a suffix.
    - Clicking this button opens the new `NseScriptSelectionDialog`, modal to the profile editor.
    - The script string selected in the `NseScriptSelectionDialog` is then populated back into the `Adw.EntryRow`.
    - You can still manually edit the NSE script string if needed.

- **No Change to Data Model:**
    - The `ScanProfile.nse_script` field (a string) and `ProfileManager` remain unchanged, as the new UI still produces a comma-separated string compatible with Nmap's `--script` argument.

This enhancement improves your experience by making it easier to discover and select common NSE scripts without needing to know their exact names beforehand.