### PR TITLE
Here's the updated plan:

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -32,6 +32,7 @@ networkmap_sources = [
   '__init__.py',
   'main.py',
   'nmap_scanner.py',
+  'nse_script_selection_dialog.py',
   'preferences_window.py',
   'profile_editor_dialog.py',
   'profile_manager.py',


### PR DESCRIPTION
Fix ModuleNotFoundError for nse_script_selection_dialog

Adds `nse_script_selection_dialog.py` to the `networkmap_sources` list in `src/meson.build`. This ensures the new dialog file is installed with the other Python modules, resolving the `ModuleNotFoundError: No module named 'networkmap.nse_script_selection_dialog'` that occurred at runtime.