### PR TITLE
Implement custom DNS and configurable Nmap defaults

### DIFF
--- a/data/com.github.mclellac.NetworkMap.gschema.xml
+++ b/data/com.github.mclellac.NetworkMap.gschema.xml
@@ -25,7 +25,7 @@
     </key>
 
     <key name="default-nmap-arguments" type="s">
-      <default>''</default>
+      <default>'-sV --host-timeout=60s'</default>
       <summary>Default arguments for Nmap scans</summary>
       <description>These arguments are automatically prepended to every Nmap scan initiated through the application. Arguments specified in the main window's 'Additional Arguments' field can override or supplement these defaults.</description>
     </key>


### PR DESCRIPTION
This commit introduces two main enhancements to Nmap scanning:

1.  Custom DNS Servers:
    - The application now reads custom DNS server IPs from GSettings (key: `com.github.mclellac.NetworkMap/dns-servers`).
    - If provided, these DNS servers are passed to the `nmap` command using the `--dns-servers` argument.
    - The preferences window already had an entry for this, which is now functional.

2.  Configurable Default Nmap Arguments:
    - The previously hardcoded Nmap arguments (`-sV --host-timeout=60s`) have been moved to a GSettings key (`com.github.mclellac.NetworkMap/default-nmap-arguments`).
    - The schema now defaults this key to `'-sV --host-timeout=60s'`, ensuring these are applied out-of-the-box.
    - You can modify or clear these default arguments via the preferences window.
    - `nmap_scanner.py` now fetches these defaults from GSettings and prepends them to the scan command. User-provided "Additional Arguments" in the UI will supplement or override these defaults.

Changes include:
- Modified `src/nmap_scanner.py` to integrate GSettings for DNS and default arguments, and to remove hardcoded options.
- Updated `data/com.github.mclellac.NetworkMap.gschema.xml` to set the new default for `default-nmap-arguments`.
- Added comprehensive unit tests in `tests/test_nmap_scanner.py` to cover the new GSettings interactions, argument parsing, and potential error conditions, using mocks for GSettings.