### PR TITLE
Fix: TypeError in NmapScanner.scan() call

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -500,8 +500,8 @@ class NetworkMapWindow(Adw.ApplicationWindow):
         Worker function to perform the Nmap scan.
         This method is run in a separate thread.
         """
-        settings = Gio.Settings.new("com.github.mclellac.NetworkMap")
-        default_args_from_settings: str = settings.get_string("default-nmap-arguments")
+        # settings = Gio.Settings.new("com.github.mclellac.NetworkMap") # No longer needed here for default_args
+        # default_args_from_settings: str = settings.get_string("default-nmap-arguments") # Removed
 
         error_type: Optional[str] = None
         error_message: Optional[str] = None
@@ -513,7 +513,7 @@ class NetworkMapWindow(Adw.ApplicationWindow):
                 do_os_fingerprint,
                 additional_args_str,
                 self.selected_nse_script,
-                default_args_str=default_args_from_settings,
+                # default_args_str=default_args_from_settings, # Removed
                 stealth_scan=do_stealth_scan,
                 port_spec=port_spec_str,                # New
                 timing_template=timing_template_val,    # New


### PR DESCRIPTION
Corrects a TypeError that occurred when initiating an Nmap scan. The `NmapScanner.scan()` method was being called with an unexpected keyword argument `default_args_str` from `src/window.py`.

This parameter was removed from `NmapScanner.scan()` in a previous commit as it now fetches default Nmap arguments directly from GSettings.

The call site in `src/window.py`'s `_run_scan` method has been updated to remove the `default_args_str` argument. The local variable `default_args_from_settings` in that method, which was used to supply this argument, has also been removed as it's no longer needed there.