### PR TITLE
feat: Enhance UI responsiveness, scan controls, and privilege handling

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -58,6 +58,7 @@ class NetworkMapWindow(Adw.ApplicationWindow):
         
         self.settings.connect("changed::results-font", lambda s, k: self._apply_font_preference())
         self.settings.connect("changed::default-nmap-arguments", self._update_nmap_command_preview) # Added
+        self.settings.connect("changed::dns-servers", self._update_nmap_command_preview) # Added for DNS servers
         
         self.profile_manager = ProfileManager()
         self.settings.connect(f"changed::{PROFILES_SCHEMA_KEY}", lambda s, k: self._populate_profile_combo())
@@ -324,13 +325,27 @@ class NetworkMapWindow(Adw.ApplicationWindow):
             self.spinner.set_visible(True)
             self.status_page.set_property("description", "Scanning...")
             self.target_entry_row.set_sensitive(False)
-            self.arguments_entry_row.set_sensitive(False)
             self.os_fingerprint_switch.set_sensitive(False)
+            self.arguments_entry_row.set_sensitive(False)
+            self.stealth_scan_switch.set_sensitive(False)
+            self.port_spec_entry_row.set_sensitive(False)
+            self.timing_template_combo_row.set_sensitive(False)
+            self.no_ping_switch.set_sensitive(False)
+            self.nse_script_combo_row.set_sensitive(False)
+            self.profile_combo_row.set_sensitive(False)
+            self.start_scan_button.set_sensitive(False)
         else:
             self.spinner.set_visible(False)
             self.target_entry_row.set_sensitive(True)
-            self.arguments_entry_row.set_sensitive(True)
             self.os_fingerprint_switch.set_sensitive(True)
+            self.arguments_entry_row.set_sensitive(True)
+            self.stealth_scan_switch.set_sensitive(True)
+            self.port_spec_entry_row.set_sensitive(True)
+            self.timing_template_combo_row.set_sensitive(True)
+            self.no_ping_switch.set_sensitive(True)
+            self.nse_script_combo_row.set_sensitive(True)
+            self.profile_combo_row.set_sensitive(True)
+            self.start_scan_button.set_sensitive(True)
 
             if state == "error":
                 self.status_page.set_property(
@@ -574,15 +589,18 @@ class NetworkMapWindow(Adw.ApplicationWindow):
              self.current_scan_results = None
 
         # Correctly hide spinner and restore sensitivity
-        if self.spinner.get_visible():
-            self.spinner.set_visible(False)
-        if (
-            not self.target_entry_row.get_sensitive()
-            and self.status_page.get_property("description") != "Scanning..."
-        ):
-            self.target_entry_row.set_sensitive(True)
-            self.arguments_entry_row.set_sensitive(True)
-            self.os_fingerprint_switch.set_sensitive(True)
+        # This logic is now fully handled by the _update_ui_state method's else block.
+        # if self.spinner.get_visible(): # This is handled by _update_ui_state
+        #     self.spinner.set_visible(False)
+        # The following block is now redundant as _update_ui_state handles all widgets.
+        # if (
+        #     not self.target_entry_row.get_sensitive()
+        #     and self.status_page.get_property("description") != "Scanning..."
+        # ):
+        #     self.target_entry_row.set_sensitive(True)
+        #     self.arguments_entry_row.set_sensitive(True)
+        #     self.os_fingerprint_switch.set_sensitive(True)
+        pass # No specific action needed here anymore regarding widget sensitivity
 
     def _clear_results_ui(self) -> None:
         """Clears the results listbox and the text view display."""


### PR DESCRIPTION
This commit introduces several improvements based on your feedback:

1.  **Live Command Preview for Preferences:**
    - The Nmap command preview in the main window now updates immediately when 'Custom DNS Servers' or 'Default Nmap Arguments' are changed in the Preferences window. This is achieved by listening to the respective GSettings key changes.

2.  **Comprehensive UI Disabling During Scans:**
    - All relevant UI controls (target, arguments, switches for OS, stealth, no-ping, port spec, timing, NSE scripts, profiles) and the 'Start Scan' button are now disabled when a scan is active and re-enabled upon completion.

3.  **Enhanced Nmap Privilege Detection and Escalation:**
    - NmapScanner now detects if root privileges are required not only for OS fingerprinting (`-O`) but also for TCP SYN scans (`-sS`, i.e., stealth scan).
    - If these operations are requested by a non-root user (either via UI switches or manually entered arguments), `pkexec` is invoked to run Nmap with elevated privileges.
    - This makes stealth scans functional for non-root users and provides a more robust way to handle operations requiring root.

Changes include:
- Modified `src/window.py`:
    - Added GSettings change listeners for live command preview updates.
    - Expanded `_update_ui_state` to disable/enable a comprehensive set of UI controls during scans.
- Modified `src/nmap_scanner.py`:
    - Updated `scan()` method to check for `-sS` in arguments and broaden the conditions for `needs_pkexec`.
- Added/updated unit tests in `tests/test_nmap_scanner.py`:
    - New tests verify the enhanced privilege detection logic, considering various combinations of root status, OS fingerprinting, and stealth scan options.