### PR TITLE
feat: Implement cross-platform privilege escalation & Nmap path detec…

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -1,4 +1,5 @@
 import os
+import sys # Added
 from typing import List
 import logging
 
@@ -84,3 +85,26 @@ def is_root() -> bool:
         True if the effective user ID is 0, False otherwise.
     """
     return os.geteuid() == 0
+
+
+def is_macos() -> bool:
+    """Checks if the current platform is macOS."""
+    return sys.platform == "darwin"
+
+def is_linux() -> bool:
+    """Checks if the current platform is Linux."""
+    return sys.platform.startswith("linux")
+
+def is_flatpak() -> bool:
+    """
+    Checks if the application is running inside a Flatpak sandbox.
+    Tries to detect Flatpak by checking for the /.flatpak-info file
+    or the FLATPAK_ID environment variable.
+    """
+    # Check for the presence of a known Flatpak file
+    if os.path.exists('/.flatpak-info'):
+        return True
+    # Check for a Flatpak-specific environment variable
+    if os.environ.get('FLATPAK_ID'):
+        return True
+    return False

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,37 +1,163 @@
 import unittest
-from unittest.mock import patch
-import sys
+from unittest.mock import patch, MagicMock # Added MagicMock
+import sys 
 import os
 
-# Adjust sys.path to allow importing from the 'src' directory
-# This is often necessary when running tests from the 'tests' directory
-# and the modules to be tested are in a sibling directory like 'src'.
-# The exact path adjustment might depend on the project structure and how tests are run.
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+# Adjust the path to import from the src directory
+# This ensures that 'from utils import ...' works correctly
+current_dir = os.path.dirname(os.path.abspath(__file__))
+project_root = os.path.dirname(current_dir)
+sys.path.insert(0, project_root)
 
-from src.utils import is_root
+# Now, import from src.utils
+# Note: The tool environment might handle path differently.
+# If 'from utils import ...' fails, it might be 'from src.utils import ...'
+# However, the original test structure implies 'utils' is directly importable after path modification.
+from src.utils import is_macos, is_linux, is_flatpak, is_root, discover_nse_scripts, apply_theme
+from gi.repository import Adw # Needed for apply_theme test
 
-class TestIsRoot(unittest.TestCase):
-    """
-    Test suite for the is_root() utility function.
-    """
+class TestPlatformUtils(unittest.TestCase):
 
-    @patch('os.geteuid')
-    def test_is_root_functionality(self, mock_geteuid):
-        """
-        Tests the is_root() function with mocked os.geteuid().
-        """
-        # Test case 1: Effective UID is 0 (root)
+    @patch('src.utils.sys.platform')
+    def test_is_macos(self, mock_sys_platform):
+        # Test when platform is macOS
+        mock_sys_platform.return_value = "darwin"
+        self.assertTrue(is_macos())
+
+        # Test when platform is not macOS (e.g., Linux)
+        mock_sys_platform.return_value = "linux"
+        self.assertFalse(is_macos())
+
+        # Test when platform is not macOS (e.g., Windows)
+        mock_sys_platform.return_value = "win32"
+        self.assertFalse(is_macos())
+
+    @patch('src.utils.sys.platform')
+    def test_is_linux(self, mock_sys_platform):
+        # Test when platform is Linux
+        mock_sys_platform.return_value = "linux"
+        self.assertTrue(is_linux())
+
+        # Test with a variation like "linux2"
+        mock_sys_platform.return_value = "linux2"
+        self.assertTrue(is_linux())
+        
+        # Test when platform is not Linux (e.g., macOS)
+        mock_sys_platform.return_value = "darwin"
+        self.assertFalse(is_linux())
+
+        # Test when platform is not Linux (e.g., Windows)
+        mock_sys_platform.return_value = "win32"
+        self.assertFalse(is_linux())
+
+    @patch('src.utils.os.environ.get')
+    @patch('src.utils.os.path.exists')
+    def test_is_flatpak(self, mock_os_path_exists, mock_os_environ_get):
+        # Scenario 1: /.flatpak-info exists
+        mock_os_path_exists.return_value = True
+        # os.environ.get should not be called due to short-circuiting.
+        # So, we don't need to set its return_value for this specific path.
+        self.assertTrue(is_flatpak())
+        mock_os_path_exists.assert_called_once_with('/.flatpak-info')
+        mock_os_environ_get.assert_not_called() # Important check for short-circuit
+
+        # Reset mocks for next scenario
+        mock_os_path_exists.reset_mock()
+        mock_os_environ_get.reset_mock()
+
+        # Scenario 2: FLATPAK_ID environment variable is set
+        mock_os_path_exists.return_value = False # /.flatpak-info does not exist
+        mock_os_environ_get.return_value = "com.github.mclellac.NetworkMap" # FLATPAK_ID is set
+        self.assertTrue(is_flatpak())
+        mock_os_path_exists.assert_called_once_with('/.flatpak-info')
+        mock_os_environ_get.assert_called_once_with('FLATPAK_ID')
+        
+        # Reset mocks for next scenario
+        mock_os_path_exists.reset_mock()
+        mock_os_environ_get.reset_mock()
+
+        # Scenario 3: Neither Flatpak indicator is present
+        mock_os_path_exists.return_value = False # /.flatpak-info does not exist
+        mock_os_environ_get.return_value = None  # FLATPAK_ID is not set
+        self.assertFalse(is_flatpak())
+        mock_os_path_exists.assert_called_once_with('/.flatpak-info')
+        mock_os_environ_get.assert_called_once_with('FLATPAK_ID')
+
+    @patch('src.utils.os.geteuid')
+    def test_is_root(self, mock_geteuid):
+        # Test when user is root
         mock_geteuid.return_value = 0
-        self.assertTrue(is_root(), "is_root() should return True when euid is 0")
+        self.assertTrue(is_root())
 
-        # Test case 2: Effective UID is non-zero (not root)
+        # Test when user is not root
         mock_geteuid.return_value = 1000
-        self.assertFalse(is_root(), "is_root() should return False when euid is not 0")
+        self.assertFalse(is_root())
 
-        # Test case 3: Effective UID is another non-zero value
-        mock_geteuid.return_value = -1 # Though typically positive, test with another non-zero
-        self.assertFalse(is_root(), "is_root() should return False when euid is not 0")
+class TestOtherUtils(unittest.TestCase):
+    @patch('src.utils.Adw.StyleManager.get_default') # Patch the static/class method
+    def test_apply_theme(self, mock_get_default_style_manager):
+        # This mock will be the return value of Adw.StyleManager.get_default()
+        mock_style_manager_instance = MagicMock()
+        mock_get_default_style_manager.return_value = mock_style_manager_instance
+        
+        apply_theme("light")
+        mock_style_manager_instance.set_color_scheme.assert_called_with(Adw.ColorScheme.FORCE_LIGHT)
+        
+        apply_theme("dark")
+        mock_style_manager_instance.set_color_scheme.assert_called_with(Adw.ColorScheme.FORCE_DARK)
+
+        apply_theme("system")
+        mock_style_manager_instance.set_color_scheme.assert_called_with(Adw.ColorScheme.DEFAULT)
+
+        apply_theme("invalid_theme_name") # Test default case
+        mock_style_manager_instance.set_color_scheme.assert_called_with(Adw.ColorScheme.DEFAULT)
+
+
+    @patch('src.utils.os.listdir')
+    @patch('src.utils.os.path.isdir', return_value=True)
+    @patch('src.utils.os.access', return_value=True)
+    @patch('src.utils.os.path.isfile', return_value=True)
+    def test_discover_nse_scripts_normal_case(self, mock_isfile, mock_access, mock_isdir, mock_listdir):
+        mock_listdir.return_value = ["http-title.nse", "smb-os-discovery.nse", "ssh-hostkey.nse", "nonscript.txt", "banner.nse"]
+        
+        scripts = discover_nse_scripts()
+        
+        self.assertIn("http-title", scripts)
+        self.assertIn("smb-os-discovery", scripts)
+        self.assertIn("ssh-hostkey", scripts)
+        self.assertIn("banner", scripts) # 'banner' is categorized as 'zzz_other'
+        self.assertNotIn("nonscript.txt", scripts)
+        
+        # Check relative order based on current SCRIPT_PREFIXES and 'zzz_other' for banner
+        # http, smb, ssh are categories. 'banner' is 'zzz_other'.
+        # Expected order: http-title, smb-os-discovery, ssh-hostkey, banner (because 'b' in banner < 'h' in http if not for prefixes)
+        # With prefixes, it should be:
+        # http-title (http category)
+        # smb-os-discovery (smb category)
+        # ssh-hostkey (ssh category)
+        # banner (zzz_other category)
+        # The SCRIPT_PREFIXES list determines category order before 'zzz_other'.
+        # 'http' is before 'smb', which is before 'ssh'. 'zzz_other' is last.
+        expected_order_segment = ["http-title", "smb-os-discovery", "ssh-hostkey", "banner"]
+        
+        # Create a list of found scripts in the expected order segment
+        found_order_segment = [s for s in scripts if s in expected_order_segment]
+        
+        self.assertEqual(found_order_segment, expected_order_segment, 
+                         f"Script order issue. Got: {scripts}")
+
+
+    @patch('src.utils.os.path.isdir', return_value=False) # Simulate script path not found
+    def test_discover_nse_scripts_no_dir(self, mock_isdir):
+        scripts = discover_nse_scripts()
+        self.assertEqual(scripts, [])
+
+    @patch('src.utils.os.listdir', side_effect=OSError("Permission denied"))
+    @patch('src.utils.os.path.isdir', return_value=True)
+    @patch('src.utils.os.access', return_value=True)
+    def test_discover_nse_scripts_os_error(self, mock_access, mock_isdir, mock_listdir):
+        scripts = discover_nse_scripts()
+        self.assertEqual(scripts, [])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
…tion

This commit significantly enhances how the application handles Nmap scans requiring root privileges, introducing cross-platform support and more robust Nmap executable detection.

Key changes:

1.  **Comprehensive Root Argument Detection:**
    - `NmapScanner.scan()` now checks for a wider range of Nmap arguments that typically require root privileges (e.g., -sS, -sU, -O, -D, --privileged, etc.), based on Nmap documentation.
    - The `--unprivileged` Nmap flag is also respected; if present, escalation is bypassed.

2.  **Platform Detection Utilities (`src/utils.py`):**
    - Added `is_macos()`, `is_linux()`, and `is_flatpak()` utility functions to determine the current operating environment.
    - Unit tests for these utilities have been added.

3.  **Cross-Platform Privilege Escalation (`src/nmap_scanner.py`):**
    - A new `_execute_with_privileges()` method in `NmapScanner` handles platform-specific privilege escalation: - macOS: Uses `osascript` to request administrator privileges. - Linux (Flatpak): Uses `flatpak-spawn --host pkexec nmap ...` to execute Nmap on the host with elevated privileges. - Linux (General): Uses `pkexec nmap ...`.
    - The main `scan()` method calls this helper when escalation is needed.

4.  **Nmap Executable Path Refinement:**
    - `NmapScanner.__init__` now uses `shutil.which('nmap')` to find the Nmap executable, with platform-aware fallbacks if not in PATH.
    - This path is used for direct (non-privileged) scans.
    - For escalated scans, the path passed to the escalation mechanism is determined contextually (e.g., just 'nmap' for `pkexec` on host via Flatpak, or a found/default path for macOS/Linux).

5.  **Unit Testing:**
    - Added extensive unit tests for `_execute_with_privileges` to mock different platforms, escalation tools, and Nmap path findings.
    - Tests also cover the logic in `scan()` for determining the Nmap command for escalation.

Conceptual Flatpak manifest requirements (e.g., for `flatpak-spawn` and PolicyKit interaction) have been noted for developer action.