### PR TITLE
Refactor: Code cleanup, robustness, and partial test fixes

### DIFF
--- a/src/nmap_scanner.py
+++ b/src/nmap_scanner.py
@@ -12,7 +12,7 @@ except ImportError as e:
 import shlex
 import subprocess
 import sys 
-import shutil # Added for shutil.which
+import shutil 
 from typing import Tuple, Optional, List, Dict, Any
 from .utils import is_root, is_macos, is_linux, is_flatpak 
 
@@ -34,272 +34,285 @@ class NmapScanner:
 
     def __init__(self) -> None:
         """
-        Initializes the NmapScanner with an nmap.PortScanner instance.
+        Initializes the NmapScanner with an nmap.PortScanner instance and Nmap path.
         """
         self.nm = nmap.PortScanner()
         self.nmap_executable_path = shutil.which('nmap')
         if not self.nmap_executable_path:
-            if is_macos():
-                self.nmap_executable_path = '/usr/local/bin/nmap'
-            else: # Linux, or other Unix-like where /usr/bin/nmap is common
-                self.nmap_executable_path = '/usr/bin/nmap'
-            # Print warning if Nmap is not found in PATH and we're resorting to defaults.
-            # This warning will also appear if the default path itself doesn't exist.
+            default_path = '/usr/local/bin/nmap' if is_macos() else '/usr/bin/nmap'
+            self.nmap_executable_path = default_path
             print(f"Warning: Nmap not found in PATH, defaulting to {self.nmap_executable_path}. "
                   "Ensure Nmap is installed and in your system's PATH or at this default location.",
                   file=sys.stderr)
-        
-        # If python-nmap needs a specific path, you can set it like this:
-        # if self.nmap_executable_path and os.path.exists(self.nmap_executable_path):
-        #    self.nm.nmap_search_path = [os.path.dirname(self.nmap_executable_path)]
-        # For now, assume python-nmap's default search or that nmap is in PATH for direct calls.
 
-
-    def _execute_with_privileges(
-        self, nmap_base_cmd_list: List[str], scan_args_list: List[str], target: str
-    ) -> subprocess.CompletedProcess:
-        
-        final_nmap_command_parts = nmap_base_cmd_list + scan_args_list + [target]
-        escalation_cmd: List[str] = []
-
-        if is_macos():
-            nmap_command_str = shlex.join(final_nmap_command_parts)
-            escaped_nmap_cmd_str = nmap_command_str.replace('"', '\\"')
-            applescript_cmd = f'do shell script "{escaped_nmap_cmd_str}" with administrator privileges'
-            escalation_cmd = ["osascript", "-e", applescript_cmd]
-        elif is_flatpak():
-            # For Flatpak, pkexec on the host will resolve 'nmap' from the host's PATH.
-            # So, final_nmap_command_parts (which starts with nmap_cmd_for_escalation, often just 'nmap') is correct.
-            escalation_cmd = ["flatpak-spawn", "--host", "pkexec"] + final_nmap_command_parts
-        elif is_linux():
-            # For general Linux, pkexec will resolve nmap_cmd_for_escalation (which could be a full path or 'nmap').
-            escalation_cmd = ["pkexec"] + final_nmap_command_parts
-        else:
-            return subprocess.CompletedProcess(
-                args=final_nmap_command_parts,
-                returncode=1, 
-                stdout="",
-                stderr=f"Privilege escalation not supported on this platform: {sys.platform}"
-            )
-
-        try:
-            completed_process = subprocess.run(
-                escalation_cmd,
-                capture_output=True,
-                text=True,
-                check=False 
-            )
-            return completed_process
-        except FileNotFoundError as e:
-            return subprocess.CompletedProcess(
-                args=escalation_cmd,
-                returncode=127, 
-                stdout="",
-                stderr=f"Escalation command '{escalation_cmd[0]}' not found. Is it installed and in PATH? Original error: {e}"
-            )
-        except Exception as e: 
-            return subprocess.CompletedProcess(
-                args=escalation_cmd,
-                returncode=1, 
-                stdout="",
-                stderr=f"An unexpected error occurred during privileged execution ({type(e).__name__}): {e}"
-            )
-
-    def scan(
-        self,
-        target: str,
-        do_os_fingerprint: bool,
-        additional_args_str: str,
-        nse_script: Optional[str] = None,
-        stealth_scan: bool = False,
-        port_spec: Optional[str] = None,
-        timing_template: Optional[str] = None,
-        no_ping: bool = False
-    ) -> Tuple[Optional[List[Dict[str, Any]]], Optional[str]]:
-        
+    def _prepare_scan_args_list(
+        self, 
+        do_os_fingerprint: bool, 
+        additional_args_str: str, 
+        nse_script: Optional[str], 
+        stealth_scan: bool, 
+        port_spec: Optional[str], 
+        timing_template: Optional[str], 
+        no_ping: bool
+    ) -> Tuple[List[str], str]:
+        """
+        Prepares the Nmap scan arguments string and list.
+        Fetches default arguments from GSettings and combines them with provided parameters.
+        """
         gsettings_default_args: Optional[str] = None
         try:
             settings = Gio.Settings.new("com.github.mclellac.NetworkMap")
             gsettings_default_args = settings.get_string("default-nmap-arguments")
         except Exception as e:
-            # Use a different name for the local sys import to avoid conflict with top-level sys
-            import sys as err_sys_local 
-            print(f"Warning: Could not retrieve default Nmap arguments from GSettings: {e}", file=err_sys_local.stderr)
+            print(f"Warning: Could not retrieve default Nmap arguments from GSettings: {e}", file=sys.stderr)
 
-        try:
-            scan_args_str = self.build_scan_args(
-                do_os_fingerprint,
-                additional_args_str,
-                nse_script,
-                gsettings_default_args,
-                stealth_scan=stealth_scan,
-                port_spec=port_spec,
-                timing_template=timing_template,
-                no_ping=no_ping
-            )
-        except NmapArgumentError as e:
-            return None, f"Argument error: {e}"
+        scan_args_str = self.build_scan_args(
+            do_os_fingerprint,
+            additional_args_str,
+            nse_script,
+            gsettings_default_args, 
+            stealth_scan=stealth_scan,
+            port_spec=port_spec,
+            timing_template=timing_template,
+            no_ping=no_ping
+        )
 
-        current_scan_args_list = []
+        current_scan_args_list: List[str] = []
         try:
             current_scan_args_list = shlex.split(scan_args_str)
         except ValueError as e:
-            return None, f"Internal error splitting scan arguments: {e}"
+            raise NmapArgumentError(f"Internal error splitting scan arguments: {e}") from e
+            
+        return current_scan_args_list, scan_args_str
 
+    def _should_escalate(self, do_os_fingerprint: bool, current_scan_args_list: List[str]) -> bool:
+        """
+        Determines if privilege escalation is needed for the scan.
+        """
         ROOT_REQUIRING_ARGS = [
-            "-sS", "-sU", "-sN", "-sF", "-sX", "-sA", "-sW", "-sM",
-            "-sI", "-sY", "-sZ", "-sO", "-O", # Added -O (OS detection), -sO is protocol scan
-            "-D", "-S", "--send-eth", "--send-ip", "--privileged"
+            "-sS", "-sU", "-sN", "-sF", "-sX", "-sA", "-sW", "-sM", 
+            "-sI", "-sY", "-sZ",                                   
+            "-sO",                                                 
+            "-O",                                                  
+            "-D",                                                  
+            "-S",                                                  
+            "--send-eth", "--send-ip",                             
+            "--privileged"                                         
         ]
         
         requires_root_argument_present = False
         if "--unprivileged" in current_scan_args_list:
-            requires_root_argument_present = False
+            requires_root_argument_present = False 
         else:
             for arg in ROOT_REQUIRING_ARGS:
                 if arg in current_scan_args_list:
                     requires_root_argument_present = True
                     break
         
-        needs_privilege_escalation = not is_root() and (do_os_fingerprint or requires_root_argument_present)
+        return not is_root() and (do_os_fingerprint or requires_root_argument_present)
+
+    def _get_nmap_escalation_command_path(self) -> str:
+        """
+        Determines the Nmap command/path to use for privilege escalation.
+        """
+        # Default to 'nmap', assuming it's in PATH for the escalation environment (e.g., host for Flatpak).
+        nmap_cmd = 'nmap' 
+        if is_macos():
+            # On macOS, Nmap is often in /usr/local/bin. shutil.which should find it if in PATH.
+            nmap_cmd = shutil.which('nmap') or '/usr/local/bin/nmap'
+        elif is_linux() and not is_flatpak():
+            # For non-Flatpak Linux, ensure pkexec can find nmap.
+            # Using a resolved path is safer if nmap isn't in root's secure_path.
+            nmap_cmd = shutil.which('nmap') or '/usr/bin/nmap'
+        # For Flatpak, 'nmap' (the default) is appropriate as flatpak-spawn --host pkexec will use the host's PATH.
+        return nmap_cmd
+
+    def _execute_with_privileges(
+        self, nmap_base_cmd_list: List[str], scan_args_list: List[str], target: str
+    ) -> subprocess.CompletedProcess:
+        """
+        Executes the Nmap command with privileges using a platform-specific method.
+        `scan_args_list` should already include -oX - if XML output is desired.
+        `nmap_base_cmd_list` is typically `['/path/to/nmap']` or `['nmap']`.
+        """
+        final_nmap_command_parts = nmap_base_cmd_list + scan_args_list + [target]
+        escalation_cmd: List[str] = []
+
+        if is_macos():
+            nmap_command_str = shlex.join(final_nmap_command_parts)
+            escaped_nmap_cmd_str = nmap_command_str.replace('"', '\\"') 
+            applescript_cmd = f'do shell script "{escaped_nmap_cmd_str}" with administrator privileges'
+            escalation_cmd = ["osascript", "-e", applescript_cmd]
+        elif is_flatpak():
+            escalation_cmd = ["flatpak-spawn", "--host", "pkexec"] + final_nmap_command_parts
+        elif is_linux():
+            escalation_cmd = ["pkexec"] + final_nmap_command_parts
+        else:
+            return subprocess.CompletedProcess(
+                args=final_nmap_command_parts, returncode=1, stdout="",
+                stderr=f"Privilege escalation not supported on this platform: {sys.platform}"
+            )
+
+        try:
+            return subprocess.run(escalation_cmd, capture_output=True, text=True, check=False)
+        except FileNotFoundError as e:
+            return subprocess.CompletedProcess(
+                args=escalation_cmd, returncode=127, stdout="",
+                stderr=f"Escalation command '{escalation_cmd[0]}' not found. Is it installed and in PATH? Original error: {e}"
+            )
+        except Exception as e: 
+            return subprocess.CompletedProcess(
+                args=escalation_cmd, returncode=1, stdout="",
+                stderr=f"An unexpected error occurred during privileged execution ({type(e).__name__}): {e}"
+            )
+
+    def scan(
+        self,
+        target: str,
+        do_os_fingerprint: bool, 
+        additional_args_str: str,
+        nse_script: Optional[str] = None,
+        stealth_scan: bool = False, 
+        port_spec: Optional[str] = None,
+        timing_template: Optional[str] = None,
+        no_ping: bool = False
+    ) -> Tuple[Optional[List[Dict[str, Any]]], Optional[str]]:
+        
+        try:
+            current_scan_args_list, scan_args_str_for_direct_scan = self._prepare_scan_args_list(
+                do_os_fingerprint, additional_args_str, nse_script,
+                stealth_scan, port_spec, timing_template, no_ping
+            )
+        except NmapArgumentError as e: 
+            return None, f"Argument error: {e}"
+        
+        needs_privilege_escalation = self._should_escalate(do_os_fingerprint, current_scan_args_list)
 
         if needs_privilege_escalation:
             xml_output_options = ["-oX", "-oA"]
             if not any(opt in current_scan_args_list for opt in xml_output_options):
                 current_scan_args_list.extend(["-oX", "-"])
             
-            nmap_cmd_for_escalation = 'nmap' 
-            if is_macos():
-                macos_nmap_path = shutil.which('nmap') or '/usr/local/bin/nmap'
-                nmap_cmd_for_escalation = macos_nmap_path
-            elif is_linux() and not is_flatpak(): # For non-Flatpak Linux, pkexec might need a full path if 'nmap' isn't in secure_path
-                linux_nmap_path = shutil.which('nmap') or '/usr/bin/nmap'
-                nmap_cmd_for_escalation = linux_nmap_path
-            # For Flatpak, 'nmap' is passed to 'pkexec' on the host, which should find it in the host's PATH.
-            # For general Linux with pkexec, if nmap is in a standard PATH location for root, 'nmap' might suffice.
-            # Using a resolved path (shutil.which or default) for Linux is safer for pkexec.
+            nmap_cmd_for_escalation = self._get_nmap_escalation_command_path()
 
             completed_process = self._execute_with_privileges(
                 [nmap_cmd_for_escalation], current_scan_args_list, target
             )
             
-            error_message_prefix = "Privileged scan execution error"
             if completed_process.returncode == 0:
                 self.nm.analyse_nmap_xml_scan(nmap_xml_output=completed_process.stdout or "")
-                if not self.nm.all_hosts() and completed_process.stderr:
-                     pass 
                 return self._parse_scan_results(do_os_fingerprint)
             else:
-                scan_error_message = f"{error_message_prefix} (Code {completed_process.returncode}): "
+                error_message = f"Privileged scan execution error (Code {completed_process.returncode}): "
                 if completed_process.stderr:
-                    scan_error_message += completed_process.stderr.strip()
-                elif completed_process.stdout and not self.nm.all_hosts(): 
-                    scan_error_message += completed_process.stdout.strip()
-                elif not completed_process.stderr and not completed_process.stdout and not self.nm.all_hosts():
-                     scan_error_message += "Unknown error during privileged scan execution (no Nmap output, no hosts found)."
-                return None, scan_error_message
+                    error_message += completed_process.stderr.strip()
+                elif completed_process.stdout: 
+                    error_message += completed_process.stdout.strip()
+                else: 
+                    error_message += "Unknown error during privileged scan execution."
+                return None, error_message
         else:
-            # Standard scan using python-nmap's direct scan method
-            # If self.nmap_executable_path is set and valid, python-nmap should use it if configured.
-            # No changes needed here based on the subtask for python-nmap's direct usage.
             try:
-                self.nm.scan(hosts=target, arguments=scan_args_str)
+                # For direct scans, python-nmap uses its own logic to find nmap,
+                # or one can configure self.nm.nmap_search_path if needed.
+                # self.nmap_executable_path (from __init__) could be used here if necessary.
+                self.nm.scan(hosts=target, arguments=scan_args_str_for_direct_scan)
                 return self._parse_scan_results(do_os_fingerprint)
             except nmap.PortScannerError as e:
                 nmap_error_output = getattr(e, 'value', str(e)).strip()
-                if not nmap_error_output:
-                    nmap_error_output = str(e)
+                if not nmap_error_output: nmap_error_output = str(e)
                 return None, f"Nmap execution error: {nmap_error_output}"
-            except Exception as e:
+            except Exception as e: 
                 return None, f"An unexpected error occurred during direct scan ({type(e).__name__}): {e}"
         
-        return None, "Scan failed due to an unexpected internal error." # Should not be reached
-
     def build_scan_args(
         self,
-        do_os_fingerprint: bool,
-        additional_args_str: str,
-        nse_script: Optional[str] = None,
-        default_args_str: Optional[str] = None,
-        stealth_scan: bool = False,
-        port_spec: Optional[str] = None,
-        timing_template: Optional[str] = None,
-        no_ping: bool = False
+        do_os_fingerprint: bool,    
+        additional_args_str: str,   
+        nse_script: Optional[str] = None,        
+        default_args_str: Optional[str] = None,  
+        stealth_scan: bool = False, 
+        port_spec: Optional[str] = None,         
+        timing_template: Optional[str] = None,   
+        no_ping: bool = False                    
     ) -> str:
+        """
+        Constructs the Nmap command-line arguments string by combining various sources:
+        GSettings defaults, user-provided additional arguments, and UI-selected options.
+        """
         if not isinstance(additional_args_str, str):
             raise NmapArgumentError("Additional arguments must be a string.")
 
         base_args: List[str] = []
-        if default_args_str:
+        if default_args_str: 
             try:
                 base_args.extend(shlex.split(default_args_str))
             except ValueError as e:
-                raise NmapArgumentError(f"Error parsing default arguments: {e}")
+                raise NmapArgumentError(f"Error parsing default arguments from GSettings: {e}")
 
         user_args: List[str] = []
-        if additional_args_str:
+        if additional_args_str: 
             try:
                 user_args.extend(shlex.split(additional_args_str))
             except ValueError as e:
-                raise NmapArgumentError(f"Error parsing additional arguments: {e}")
+                raise NmapArgumentError(f"Error parsing additional arguments from UI: {e}")
 
         final_args: List[str] = base_args + user_args
 
         if do_os_fingerprint and "-O" not in final_args:
             final_args.append("-O")
 
-        if nse_script:
+        script_arg_already_present = any(
+            arg == f"--script={nse_script}" or arg.startswith("--script=") or arg == "--script" 
+            for arg in final_args
+        )
+        if nse_script and not script_arg_already_present:
             final_args.append(f"--script={nse_script}")
 
         if stealth_scan:
-            has_conflicting_scan_type = any(scan_flag in final_args for scan_flag in ["-sT", "-sA", "-sW", "-sM", "-sN", "-sF", "-sX"])
+            has_conflicting_scan_type = any(scan_flag in final_args for scan_flag in 
+                                            ["-sT", "-sA", "-sW", "-sM", "-sN", "-sF", "-sX"])
             if not has_conflicting_scan_type and "-sS" not in final_args:
                 final_args.append("-sS")
-            elif not has_conflicting_scan_type and "-sS" in final_args:
-                pass 
-            elif has_conflicting_scan_type:
-                import sys as err_sys_local 
-                print(f"Warning: Stealth scan (-sS) conflicts with existing scan type arguments: {' '.join(final_args)}. User arguments will take precedence.", file=err_sys_local.stderr)
-        
-        if no_ping:
-            if "-Pn" not in final_args:
-                final_args.append("-Pn")
+            elif has_conflicting_scan_type and "-sS" not in final_args: 
+                 print(f"Warning: Stealth scan (-sS) conflicts with existing scan type arguments: {' '.join(final_args)}. "
+                       "User arguments will take precedence.", file=sys.stderr)
+
+        if no_ping and "-Pn" not in final_args:
+            final_args.append("-Pn")
 
         if port_spec and port_spec.strip():
-            if not any(arg == "-p" for arg in final_args):
-                final_args.append("-p")
-                final_args.append(port_spec.strip())
-            else:
-                import sys as err_sys_local
-                print(f"Warning: Port specification (-p) might conflict with existing arguments: {' '.join(final_args)}. User-provided/additional arguments may take precedence or cause issues.", file=err_sys_local.stderr)
+            port_arg_present = any(arg == "-p" or (arg.startswith("-p") and not arg[2:].isdigit()) for arg in final_args)
+            if not port_arg_present: 
+                final_args.extend(["-p", port_spec.strip()])
         
         if timing_template and timing_template.strip():
-            if not any(arg.startswith("-T") and len(arg) == 3 and arg[2].isdigit() for arg in final_args):
+            timing_arg_present = any(arg.startswith("-T") and len(arg) == 3 and arg[2].isdigit() for arg in final_args)
+            if not timing_arg_present:
                 final_args.append(timing_template.strip())
-            else:
-                import sys as err_sys_local
-                print(f"Warning: Timing template ({timing_template}) might conflict with existing -T arguments: {' '.join(final_args)}. User-provided/additional arguments may take precedence or cause issues.", file=err_sys_local.stderr)
-
+            
         try:
-            settings = Gio.Settings.new("com.github.mclellac.NetworkMap")
-            dns_servers_str = settings.get_string("dns-servers")
+            gsettings_dns = Gio.Settings.new("com.github.mclellac.NetworkMap") 
+            dns_servers_str = gsettings_dns.get_string("dns-servers")
             if dns_servers_str:
                 dns_servers = [server.strip() for server in dns_servers_str.split(',') if server.strip()]
-                if dns_servers:
-                    if not any(arg.startswith("--dns-servers") for arg in final_args):
-                        final_args.append(f"--dns-servers={','.join(dns_servers)}")
-                    else:
-                        import sys as err_sys_local
-                        print("Warning: --dns-servers argument already provided by user or default args. GSettings will not override.", file=err_sys_local.stderr)
+                if dns_servers and not any(arg.startswith("--dns-servers") for arg in final_args):
+                    final_args.append(f"--dns-servers={','.join(dns_servers)}")
+                elif any(arg.startswith("--dns-servers") for arg in final_args) and dns_servers:
+                     print("Warning: --dns-servers argument already provided by user or GSettings defaults. "
+                           "GSettings value for DNS will not override.", file=sys.stderr)
         except Exception as e:
-            import sys as err_sys_local
-            print(f"Warning: Could not retrieve DNS servers from GSettings: {e}", file=err_sys_local.stderr)
+            print(f"Warning: Could not retrieve DNS servers from GSettings for build_scan_args: {e}", file=sys.stderr)
 
         return " ".join(final_args)
 
     def _parse_scan_results(
         self, do_os_fingerprint: bool
     ) -> Tuple[List[Dict[str, Any]], Optional[str]]:
+        """
+        Parses the Nmap scan results from the PortScanner object.
+        `do_os_fingerprint` is a hint for parsing OS-related data.
+        """
         hosts_data: List[Dict[str, Any]] = []
         scanned_host_ids = self.nm.all_hosts()
 
@@ -365,9 +378,9 @@ class NmapScanner:
                             f"  <b>Port:</b> {escaped_port_id}/{escaped_proto_short:<3}  <b>State:</b> {escaped_port_state:<10} <b>Service:</b> {service_info_str}"
                         )
                 
-                if do_os_fingerprint and "osmatch" in host_scan_data:
+                if do_os_fingerprint and "osmatch" in host_scan_data: 
                     os_matches = host_scan_data.get("osmatch", [])
-                    if os_matches:
+                    if os_matches: 
                         best_os_match = os_matches[0]
                         name = GLib.markup_escape_text(best_os_match.get("name", "N/A"))
                         accuracy = GLib.markup_escape_text(str(best_os_match.get("accuracy", "N/A")))
@@ -404,7 +417,7 @@ class NmapScanner:
                                 "accuracy": str(os_class_data.get('accuracy', 'N/A'))
                             })
                         host_info["os_fingerprint"] = os_fingerprint_details
-                    elif do_os_fingerprint:
+                    elif do_os_fingerprint: 
                         raw_details_parts.append("\n<b>OS Fingerprint:</b> No OS matches found.")
 
                 host_info["raw_details_text"] = "\n".join(raw_details_parts)
@@ -417,7 +430,7 @@ class NmapScanner:
                     f"Unexpected error parsing data for host {host_id} ({type(e).__name__}): {e}"
                 )
 
-        if not hosts_data and scanned_host_ids:
+        if not hosts_data and scanned_host_ids: 
             return [], "No information parsed for scanned hosts. They might be down or heavily filtered."
         
         return hosts_data, None

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,19 +1,19 @@
 import os
-import sys # Added
-from typing import List
+import sys 
+from typing import List, Tuple # Added Tuple for type hint
 import logging
 
 from gi.repository import Adw
 
 
 def apply_theme(theme: str):
-    """Applies the selected theme."""
+    """Applies the selected Adwaita theme using Adw.StyleManager."""
     style_manager = Adw.StyleManager.get_default()
     if theme == "light":
         style_manager.set_color_scheme(Adw.ColorScheme.FORCE_LIGHT)
     elif theme == "dark":
         style_manager.set_color_scheme(Adw.ColorScheme.FORCE_DARK)
-    else:
+    else: # Default or system theme
         style_manager.set_color_scheme(Adw.ColorScheme.DEFAULT)
 
 
@@ -26,23 +26,22 @@ def discover_nse_scripts() -> List[str]:
         Returns an empty list if the directory is not accessible or an error occurs.
     """
     categorized_scripts: List[Tuple[str, str]] = []
-    default_path = "/usr/share/nmap/scripts/"
+    default_path = "/usr/share/nmap/scripts/" # Standard Nmap script directory
 
-    # Define common prefixes for categorization
-    # Using "zzz_" for the default category ensures it sorts last.
+    # Define common prefixes for categorization.
+    # Using "zzz_" for the default category ensures it sorts last for display.
     DEFAULT_CATEGORY = "zzz_other"
     SCRIPT_PREFIXES = [
         'http', 'smb', 'dns', 'ssh', 'smtp', 'ftp', 'imap', 'pop3', 
         'mysql', 'oracle', 'ms-sql', 'rdp', 'vnc', 'ssl', 'tls', 'snmp', 'whois',
         'broadcast', 'discovery', 'dos', 'exploit', 'external', 'fuzzer', 
         'intrusive', 'malware', 'safe', 'version', 'vuln' 
-        # 'auth' can be too generic, consider if it's needed or if specific auth types are better
+        # 'auth' can be too generic; specific auth types might be better if needed.
     ]
-
 
     if not os.path.isdir(default_path) or not os.access(default_path, os.R_OK):
         logging.warning(f"NSE script directory {default_path} not found or not readable.")
-        return [] # Return empty list as per original behavior
+        return [] 
 
     try:
         for item_name in os.listdir(default_path):
@@ -53,26 +52,26 @@ def discover_nse_scripts() -> List[str]:
                     
                     assigned_category = DEFAULT_CATEGORY
                     for prefix in SCRIPT_PREFIXES:
-                        # We check for "prefix-" or "prefix_" to be more specific than just startswith(prefix)
-                        # to avoid 'http' matching 'httpfoo' if 'httpfoo' isn't a category.
-                        # Or, if a script is named like 'sshnoop.nse', it won't be miscategorized as 'ssh'.
+                        # Check for "prefix-" or "prefix_" to be more specific than just startswith(prefix),
+                        # e.g., to avoid 'http' matching 'httpfoo' if 'httpfoo' isn't a category,
+                        # or if a script is named 'sshnoop.nse', it won't be miscategorized as 'ssh'.
                         if script_name_no_ext.startswith(prefix + '-') or \
                            script_name_no_ext.startswith(prefix + '_'):
                             assigned_category = prefix
                             break 
-                        # Some scripts might be just the prefix itself e.g. "banner.nse" -> should not be categorized by "ban"
-                        # This is implicitly handled as "banner" would not start with "banner-"
+                        # Scripts named just the prefix (e.g., "banner.nse") are implicitly handled
+                        # as they won't start with "prefix-".
                     
                     categorized_scripts.append((assigned_category, script_name_no_ext))
 
-        categorized_scripts.sort() # Sorts by category (prefix), then by script name
+        # Sorts by category (prefix alphabetical), then by script name within each category.
+        categorized_scripts.sort() 
         
-        # Extract just the script names for the final list
         final_script_names = [name for category, name in categorized_scripts]
 
     except OSError as e:
         logging.warning(f"Error reading NSE script directory {default_path}: {e}")
-        return [] # Return empty list on error
+        return [] 
 
     return final_script_names
 
@@ -101,10 +100,8 @@ def is_flatpak() -> bool:
     Tries to detect Flatpak by checking for the /.flatpak-info file
     or the FLATPAK_ID environment variable.
     """
-    # Check for the presence of a known Flatpak file
-    if os.path.exists('/.flatpak-info'):
+    if os.path.exists('/.flatpak-info'): # Standard Flatpak sandbox file
         return True
-    # Check for a Flatpak-specific environment variable
-    if os.environ.get('FLATPAK_ID'):
+    if os.environ.get('FLATPAK_ID'): # Standard Flatpak environment variable
         return True
     return False

--- a/src/window.py
+++ b/src/window.py
@@ -13,15 +13,14 @@ from .profile_manager import ScanProfile, ProfileManager, PROFILES_SCHEMA_KEY
 class NetworkMapWindow(Adw.ApplicationWindow):
     __gtype_name__ = "NetworkMapWindow"
 
-    MAX_HISTORY_SIZE = 20 # Define max history size
-    TARGET_HISTORY_SCHEMA_KEY = "target-history" # Define for clarity
+    MAX_HISTORY_SIZE = 20 
+    TARGET_HISTORY_SCHEMA_KEY = "target-history"
 
     target_entry_row: Adw.EntryRow = Gtk.Template.Child("target_entry_row")
     os_fingerprint_switch: Gtk.Switch = Gtk.Template.Child("os_fingerprint_switch")
     arguments_entry_row: Adw.EntryRow = Gtk.Template.Child("arguments_entry_row")
     nse_script_combo_row: Adw.ComboRow = Gtk.Template.Child("nse_script_combo_row")
     spinner: Gtk.Spinner = Gtk.Template.Child("spinner")
-    # text_view: Gtk.TextView = Gtk.Template.Child("text_view") # Removed
     status_page: Adw.StatusPage = Gtk.Template.Child("status_page")
     results_listbox: Gtk.ListBox = Gtk.Template.Child("results_listbox")
     toast_overlay: Adw.ToastOverlay = Gtk.Template.Child("toast_overlay")
@@ -40,606 +39,430 @@ class NetworkMapWindow(Adw.ApplicationWindow):
         self.nmap_scanner: NmapScanner = NmapScanner()
         self.current_scan_results: Optional[List[Dict[str, Any]]] = None
         self.selected_nse_script: Optional[str] = None
-        self.nse_script_filter: Optional[Gtk.StringFilter] = None # For NSE script search
-        # self.selected_port_spec: Optional[str] = None # Removed, will read directly
+        self.nse_script_filter: Optional[Gtk.StringFilter] = None 
         self.selected_timing_template: Optional[str] = None
-        self.timing_options: Dict[str, Optional[str]] = {} # Will be populated
+        self.timing_options: Dict[str, Optional[str]] = {} 
         
         self.settings = Gio.Settings.new("com.github.mclellac.NetworkMap")
-        self.target_history_list: List[str] = list(self.settings.get_strv("target-history"))
+        self.target_history_list: List[str] = list(self.settings.get_strv(self.TARGET_HISTORY_SCHEMA_KEY))
         
-        # Initialize and apply CSS provider for font settings
         self.font_css_provider = Gtk.CssProvider()
-        # The following line was removed as self.text_view no longer exists:
-        # self.text_view.get_style_context().add_provider(
-        #     self.font_css_provider, 
-        #     Gtk.STYLE_PROVIDER_PRIORITY_USER
-        # )
         
         self.settings.connect("changed::results-font", lambda s, k: self._apply_font_preference())
-        self.settings.connect("changed::default-nmap-arguments", self._update_nmap_command_preview) # Added
-        self.settings.connect("changed::dns-servers", self._update_nmap_command_preview) # Added for DNS servers
+        self.settings.connect("changed::default-nmap-arguments", self._update_nmap_command_preview)
+        self.settings.connect("changed::dns-servers", self._update_nmap_command_preview)
         
         self.profile_manager = ProfileManager()
         self.settings.connect(f"changed::{PROFILES_SCHEMA_KEY}", lambda s, k: self._populate_profile_combo())
         self.settings.connect(f"changed::{self.TARGET_HISTORY_SCHEMA_KEY}", self._on_target_history_changed)
-
-        # Target history completion setup (REMOVED)
         
-        self._connect_signals() # Original signals
+        self._connect_signals()
         
-        # Profile combo related signals and initial population
         self._populate_profile_combo() 
         self.profile_combo_row.connect("notify::selected", self._on_profile_selected)
 
-        self._populate_nse_script_combo() # Ensure NSE scripts are loaded at startup
-        self._populate_timing_template_combo() # Populate timing options
-        self._update_nmap_command_preview() # Initial command preview
+        self._populate_nse_script_combo() 
+        self._populate_timing_template_combo() 
+        self._update_nmap_command_preview() 
         self._update_ui_state("ready")
-        GLib.idle_add(self._apply_font_preference) # Apply initial font preference after UI is fully initialized
+        GLib.idle_add(self._apply_font_preference)
 
     def _populate_profile_combo(self) -> None:
-        # print("DEBUG: Repopulating profile combo box") # For checking GSettings change signal
+        """Populates the scan profile selection combobox."""
         profiles = self.profile_manager.load_profiles()
         profile_names: List[str] = ["Manual Configuration"] + [p['name'] for p in profiles]
         
         string_list_model = Gtk.StringList.new(profile_names)
         self.profile_combo_row.set_model(string_list_model)
-        self.profile_combo_row.set_selected(0) # Default to "Manual Configuration"
-        # When set_selected(0) is called, if the current selection is already 0,
-        # _on_profile_selected might not be triggered.
-        # If it's different, it will trigger _on_profile_selected, which will call _apply_scan_profile(None).
-        # If it's already 0, we might need to manually ensure UI is in "manual" state.
-        # However, _apply_scan_profile(None) in _on_profile_selected handles this.
-        # If the selection was already 0, and we want to ensure a "reset" happens
-        # when profiles are repopulated (e.g. a profile was deleted, and "Manual" remains selected),
-        # we might explicitly call _apply_scan_profile(None) here.
-        # For now, relying on _on_profile_selected to handle the application of None.
+        self.profile_combo_row.set_selected(0) 
 
     def _on_profile_selected(self, combo_row: Adw.ComboRow, pspec: GObject.ParamSpec) -> None:
+        """Handles changes in the selected scan profile."""
         selected_idx = combo_row.get_selected()
         model = combo_row.get_model()
 
         if not isinstance(model, Gtk.StringList) or selected_idx < 0:
-            # This can happen if the model is temporarily not a Gtk.StringList during updates
-            # or if no item is selected (-1).
             return
 
         selected_name = model.get_string(selected_idx)
 
-        if selected_idx == 0: # "Manual Configuration"
+        if selected_idx == 0: 
             self._apply_scan_profile(None) 
-            # print("DEBUG: Switched to Manual Configuration")
         else:
             profile_name = selected_name
-            profiles = self.profile_manager.load_profiles() # Load fresh list
-            found_profile: Optional[ScanProfile] = None
-            for p in profiles:
-                if p['name'] == profile_name:
-                    found_profile = p
-                    break
+            profiles = self.profile_manager.load_profiles() 
+            found_profile = next((p for p in profiles if p['name'] == profile_name), None)
             
             if found_profile:
                 self._apply_scan_profile(found_profile)
-                # print(f"DEBUG: Applied profile '{profile_name}'")
-            else:
-                # This case should ideally not happen if profiles are populated correctly
-                # print(f"Error: Profile '{profile_name}' selected but not found in manager.")
-                # Fallback: set to manual and apply None profile
+            else: 
                 self.profile_combo_row.set_selected(0) 
                 self._apply_scan_profile(None)
 
     def _populate_timing_template_combo(self) -> None:
         """Populates the timing template combo box."""
         self.timing_options = {
-            "Default (T3)": None, 
-            "Paranoid (T0)": "-T0",
-            "Sneaky (T1)": "-T1",
-            "Polite (T2)": "-T2",
-            "Aggressive (T4)": "-T4",
-            "Insane (T5)": "-T5",
+            "Default (T3)": None, "Paranoid (T0)": "-T0", "Sneaky (T1)": "-T1",
+            "Polite (T2)": "-T2", "Aggressive (T4)": "-T4", "Insane (T5)": "-T5",
         }
-        string_list_model = Gtk.StringList.new(list(self.timing_options.keys()))
-        self.timing_template_combo_row.set_model(string_list_model)
-        self.timing_template_combo_row.set_selected(0) # Default to "Default (T3)"
+        self.timing_template_combo_row.set_model(Gtk.StringList.new(list(self.timing_options.keys())))
+        self.timing_template_combo_row.set_selected(0) 
+
+    def _get_current_scan_parameters(self) -> Dict[str, Any]:
+        """Collects current scan parameters from UI elements."""
+        return {
+            "target": self.target_entry_row.get_text().strip(),
+            "do_os_fingerprint": self.os_fingerprint_switch.get_active(),
+            "additional_args_str": self.arguments_entry_row.get_text(),
+            "nse_script": self.selected_nse_script,
+            "stealth_scan": self.stealth_scan_switch.get_active(),
+            "port_spec": self.port_spec_entry_row.get_text().strip(), # Key changed to match build_scan_args
+            "timing_template": self.selected_timing_template, # Key changed to match build_scan_args
+            "no_ping": self.no_ping_switch.get_active() # Key changed to match build_scan_args
+        }
 
     def _update_nmap_command_preview(self, *args) -> None:
         """Updates the Nmap command preview row based on current UI settings."""
-        target_text = self.target_entry_row.get_text().strip()
-        do_os_fingerprint = self.os_fingerprint_switch.get_active()
-        do_stealth_scan = self.stealth_scan_switch.get_active()
-        do_no_ping = self.no_ping_switch.get_active() # New
-        port_spec_text = self.port_spec_entry_row.get_text().strip() # New
-        selected_timing = self.selected_timing_template # New
-        additional_args_str = self.arguments_entry_row.get_text()
-        selected_script = self.selected_nse_script 
+        scan_params = self._get_current_scan_parameters()
+        target_text = scan_params["target"]
+        
+        # Note: self.nmap_scanner.build_scan_args expects 'default_args_str'
+        # which is not part of _get_current_scan_parameters as it's from GSettings.
         default_args_from_settings = self.settings.get_string("default-nmap-arguments")
 
         try:
             args_string = self.nmap_scanner.build_scan_args(
-                do_os_fingerprint=do_os_fingerprint,
-                additional_args_str=additional_args_str,
-                nse_script=selected_script,
-                default_args_str=default_args_from_settings,
-                stealth_scan=do_stealth_scan,
-                port_spec=port_spec_text,        # New
-                timing_template=selected_timing, # New
-                no_ping=do_no_ping               # New
+                do_os_fingerprint=scan_params["do_os_fingerprint"],
+                additional_args_str=scan_params["additional_args_str"],
+                nse_script=scan_params["nse_script"],
+                default_args_str=default_args_from_settings, # Pass GSettings value
+                stealth_scan=scan_params["stealth_scan"],
+                port_spec=scan_params["port_spec"],
+                timing_template=scan_params["timing_template"],
+                no_ping=scan_params["no_ping"]
             )
         except NmapArgumentError as e:
             self.nmap_command_preview_row.set_text(f"Error in arguments: {e}")
             return
-        except Exception as e: # Catch any other unexpected error
+        except Exception as e: 
             self.nmap_command_preview_row.set_text(f"Error building command: {e}")
             return
 
-        if not target_text:
-            full_command = f"nmap {args_string} <target_host>"
-        else:
-            full_command = f"nmap {args_string} {target_text}"
-        
+        full_command = f"nmap {args_string} {target_text if target_text else '<target_host>'}"
         self.nmap_command_preview_row.set_text(full_command)
 
     def _apply_font_preference(self) -> None:
-        # Applies the font preference from GSettings to the Gtk.TextViews within HostInfoExpanderRows.
+        """Applies the font preference from GSettings to dynamic Gtk.TextViews."""
         font_str = self.settings.get_string("results-font")
-        # print(f"DEBUG: Font string from GSettings: '{font_str}'", file=sys.stderr)
-
         css_data = ""
         if font_str:
             try:
                 font_desc = Pango.FontDescription.from_string(font_str)
                 family = font_desc.get_family()
                 size_points = 0
-                # Pango.VERSION is available from gi.repository.Pango
-                # Pango.version_to_int() converts a string version like "1.44.0" to an integer for comparison.
-                # However, Pango.VERSION itself is an integer, so direct comparison is fine.
-                # For Pango < 1.44, get_size_is_set() is not available.
-                # Pango 1.44 is required for get_size_is_set. Let's assume Pango versions are comparable as integers.
-                # A common way to check Pango version features is by checking Pango.VERSION >= Pango.VERSION_1_44 (if such constants exist)
-                # or by Pango.VERSION >= pango_version_to_int(1,44,0)
-                # For simplicity here, we'll use a hardcoded integer if Pango.VERSION_1_44 is not available.
-                # Pango version encoding: major * 10000 + minor * 100 + micro. So 1.44.0 is 14400.
-                
-                # It's safer to check for the attribute directly to avoid issues with Pango.VERSION format/constants
                 if hasattr(font_desc, 'get_size_is_set') and font_desc.get_size_is_set():
                     size_points = font_desc.get_size() / Pango.SCALE
-                elif not hasattr(font_desc, 'get_size_is_set'): # Fallback for older Pango
+                elif not hasattr(font_desc, 'get_size_is_set'): 
                     pango_size = font_desc.get_size()
-                    if pango_size > 0: # get_size() returns 0 if not set in points
-                        size_points = pango_size / Pango.SCALE
-                # If size_points is still 0, it means size was not explicitly set or couldn't be retrieved.
+                    if pango_size > 0: size_points = pango_size / Pango.SCALE
                 
-                # print(f"DEBUG: Parsed - Family: '{family}', Size Points: {size_points}", file=sys.stderr)
-
                 if family and size_points > 0:
                     css_data = f"* {{ font-family: \"{family}\"; font-size: {size_points}pt; }}"
                 elif family:
                     css_data = f"* {{ font-family: \"{family}\"; }}"
-                    # print(f"DEBUG: Applying family only: '{family}'", file=sys.stderr)
-                # else:
-                    # print(f"Warning: Could not parse family name effectively from font string '{font_str}'. CSS will be empty.", file=sys.stderr)
             except Exception as e:
                 print(f"Error parsing font string '{font_str}' with Pango: {e}. CSS will be empty.", file=sys.stderr)
         
-        # print(f"DEBUG: Generated CSS data: '{css_data}'", file=sys.stderr)
-
         if hasattr(self, 'font_css_provider'):
             self.font_css_provider.load_from_data(css_data.encode())
-            # Apply to existing HostInfoExpanderRows
-            for row in self.results_listbox:
-                if isinstance(row, HostInfoExpanderRow):
-                    text_view = row.get_text_view()
+            # Iterate over ListBox children safely
+            child = self.results_listbox.get_first_child()
+            while child:
+                if isinstance(child, HostInfoExpanderRow):
+                    text_view = child.get_text_view()
                     if text_view:
                         text_view.get_style_context().add_provider(
-                            self.font_css_provider,
-                            Gtk.STYLE_PROVIDER_PRIORITY_USER
-                        )
-        # else:
-            # print("Error: font_css_provider not initialized before applying font preference.", file=sys.stderr)
+                            self.font_css_provider, Gtk.STYLE_PROVIDER_PRIORITY_USER)
+                child = child.get_next_sibling()
+
 
     def _populate_nse_script_combo(self) -> None:
-        """Populates the NSE script combo box with discovered scripts and sets up filtering."""
+        """Populates the NSE script combo box with discovered scripts."""
         discovered_scripts = discover_nse_scripts()
         combo_items: List[str] = ["None"] + discovered_scripts
         string_list_model = Gtk.StringList.new(combo_items)
 
-        # Create and configure the string filter
-        # Create an expression to get the 'string' property from Gtk.StringObject
-        # Gtk.StringObject is the type of items in a Gtk.StringList.
         expression = Gtk.PropertyExpression.new(Gtk.StringObject, None, "string")
         self.nse_script_filter = Gtk.StringFilter.new(expression)
         self.nse_script_filter.set_match_mode(Gtk.StringFilterMatchMode.SUBSTRING)
         self.nse_script_filter.set_ignore_case(True)
 
-        # Create the filter list model
         filter_model = Gtk.FilterListModel.new(string_list_model, self.nse_script_filter)
-        
         self.nse_script_combo_row.set_model(filter_model)
-        self.nse_script_combo_row.set_selected(0) # Select "None" by default
-
-    # Removed _on_nse_search_changed method as Adw.ComboRow handles the filter automatically
+        self.nse_script_combo_row.set_selected(0) 
 
     def _connect_signals(self) -> None:
         """Connects UI signals to their handlers."""
         self.target_entry_row.connect("apply", self._on_scan_button_clicked)
         self.start_scan_button.connect("clicked", self._on_start_scan_button_clicked)
 
-        # Connect signals for command preview updates
         self.target_entry_row.connect("notify::text", self._update_nmap_command_preview)
         self.os_fingerprint_switch.connect("notify::active", self._update_nmap_command_preview)
         self.stealth_scan_switch.connect("notify::active", self._update_nmap_command_preview)
         self.no_ping_switch.connect("notify::active", self._update_nmap_command_preview)
         self.arguments_entry_row.connect("notify::text", self._update_nmap_command_preview)
         self.port_spec_entry_row.connect("notify::text", self._update_nmap_command_preview)
-        self.nse_script_combo_row.connect("notify::selected", self._on_nse_script_selected) # Also updates preview
+        self.nse_script_combo_row.connect("notify::selected", self._on_nse_script_selected) 
         self.timing_template_combo_row.connect("notify::selected", self._on_timing_template_selected)
 
-        # Manual connection for search_entry's "search-changed" is no longer needed.
-        # Adw.ComboRow with enable-search=True and a Gtk.FilterListModel
-        # (containing a Gtk.StringFilter) handles this internally.
-        # The Gtk.StringFilter's 'search' property is bound/updated by Adw.ComboRow.
-
     def _on_nse_script_selected(self, combo_row: Adw.ComboRow, pspec: GObject.ParamSpec) -> None:
-        """
-        Handles the selection change in the NSE script combo box.
-        Updates `self.selected_nse_script` based on the new selection.
-        """
-        selected_item = combo_row.get_selected_item() # This gets the Gtk.StringObject
-
+        """Handles selection change in the NSE script combo box."""
+        selected_item = combo_row.get_selected_item() 
         if isinstance(selected_item, Gtk.StringObject):
             selected_value = selected_item.get_string()
-            if selected_value == "None":
-                self.selected_nse_script = None
-            else:
-                self.selected_nse_script = selected_value
+            self.selected_nse_script = None if selected_value == "None" else selected_value
         else:
-            # This case might occur if nothing is selected or model is empty
             self.selected_nse_script = None
-        
-        self._update_nmap_command_preview() # Update preview when script changes
+        self._update_nmap_command_preview()
 
     def _on_timing_template_selected(self, combo_row: Adw.ComboRow, pspec: GObject.ParamSpec) -> None:
         """Handles selection changes in the timing template combo box."""
         selected_idx = combo_row.get_selected()
-        model = combo_row.get_model() # This is a Gtk.StringList
-        
+        model = combo_row.get_model()
         if isinstance(model, Gtk.StringList) and selected_idx >= 0:
             display_string = model.get_string(selected_idx)
             self.selected_timing_template = self.timing_options.get(display_string)
-        else: # Should not happen if model is correctly populated
+        else: 
             self.selected_timing_template = None
-            
         self._update_nmap_command_preview()
 
-
     def _update_ui_state(self, state: str, message: Optional[str] = None) -> None:
-        """
-        Updates the UI elements like spinner and status page based on application state.
+        """Updates UI elements based on application state (e.g., scanning, error, success)."""
+        is_scanning = (state == "scanning")
+        self.spinner.set_visible(is_scanning)
+        
+        sensitive = not is_scanning
+        self.target_entry_row.set_sensitive(sensitive)
+        self.os_fingerprint_switch.set_sensitive(sensitive)
+        self.arguments_entry_row.set_sensitive(sensitive)
+        self.stealth_scan_switch.set_sensitive(sensitive)
+        self.port_spec_entry_row.set_sensitive(sensitive)
+        self.timing_template_combo_row.set_sensitive(sensitive)
+        self.no_ping_switch.set_sensitive(sensitive)
+        self.nse_script_combo_row.set_sensitive(sensitive)
+        self.profile_combo_row.set_sensitive(sensitive)
+        self.start_scan_button.set_sensitive(sensitive)
 
-        Args:
-            state: The current state ("scanning", "error", "success", "ready", "no_results", "no_data").
-            message: An optional message, typically for errors or specific statuses.
-        """
-        if state == "scanning":
-            self.spinner.set_visible(True)
+        if is_scanning:
             self.status_page.set_property("description", "Scanning...")
-            self.target_entry_row.set_sensitive(False)
-            self.os_fingerprint_switch.set_sensitive(False)
-            self.arguments_entry_row.set_sensitive(False)
-            self.stealth_scan_switch.set_sensitive(False)
-            self.port_spec_entry_row.set_sensitive(False)
-            self.timing_template_combo_row.set_sensitive(False)
-            self.no_ping_switch.set_sensitive(False)
-            self.nse_script_combo_row.set_sensitive(False)
-            self.profile_combo_row.set_sensitive(False)
-            self.start_scan_button.set_sensitive(False)
-        else:
-            self.spinner.set_visible(False)
-            self.target_entry_row.set_sensitive(True)
-            self.os_fingerprint_switch.set_sensitive(True)
-            self.arguments_entry_row.set_sensitive(True)
-            self.stealth_scan_switch.set_sensitive(True)
-            self.port_spec_entry_row.set_sensitive(True)
-            self.timing_template_combo_row.set_sensitive(True)
-            self.no_ping_switch.set_sensitive(True)
-            self.nse_script_combo_row.set_sensitive(True)
-            self.profile_combo_row.set_sensitive(True)
-            self.start_scan_button.set_sensitive(True)
-
-            if state == "error":
-                self.status_page.set_property(
-                    "description", f"Scan Failed: {message or 'Unknown error'}"
-                )
-            elif state == "success":
-                self.status_page.set_property("description", "Scan Complete.")
-            elif state == "ready":
-                self.status_page.set_property("description", message or "Ready to scan.")
-            elif state == "no_results":
-                self.status_page.set_property("description", "Scan Complete: No hosts found.")
-            elif state == "no_data":
-                self.status_page.set_property("description", "Scan Complete: No data received.")
+        elif state == "error":
+            self.status_page.set_property("description", f"Scan Failed: {message or 'Unknown error'}")
+        elif state == "success":
+            self.status_page.set_property("description", "Scan Complete.")
+        elif state == "ready":
+            self.status_page.set_property("description", message or "Ready to scan.")
+        elif state == "no_results":
+            self.status_page.set_property("description", "Scan Complete: No hosts found.")
+        elif state == "no_data":
+            self.status_page.set_property("description", "Scan Complete: No data received.")
 
     def _apply_scan_profile(self, profile: Optional[ScanProfile]) -> None:
-        """Applies the settings from a given scan profile to the UI."""
-        if not profile:
-            # Potentially reset fields to default or a "manual" state
-            # For now, if None is passed, perhaps we clear relevant fields or set to a default
-            # This behavior might be refined when the profile selection UI is built
+        """Applies settings from a scan profile to the UI. Resets if profile is None."""
+        if not profile: 
             self.os_fingerprint_switch.set_active(False)
             self.stealth_scan_switch.set_active(False)
             self.no_ping_switch.set_active(False)
             self.port_spec_entry_row.set_text("")
             self.arguments_entry_row.set_text("")
-            self.nse_script_combo_row.set_selected(0) # "None"
-            self.timing_template_combo_row.set_selected(0) # "Default (T3)"
-            # self.selected_nse_script and self.selected_timing_template should also be reset
+            self.nse_script_combo_row.set_selected(0) 
+            self.timing_template_combo_row.set_selected(0) 
             self.selected_nse_script = None 
-            selected_timing_display_name = list(self.timing_options.keys())[0] # "Default (T3)"
-            self.selected_timing_template = self.timing_options[selected_timing_display_name]
-
-            self._update_nmap_command_preview()
-            return
-
-        self.os_fingerprint_switch.set_active(profile['os_fingerprint'])
-        self.stealth_scan_switch.set_active(profile['stealth_scan'])
-        self.no_ping_switch.set_active(profile['no_ping'])
-        self.port_spec_entry_row.set_text(profile['ports'])
-        self.arguments_entry_row.set_text(profile['additional_args'])
-
-        # Apply NSE script
-        if profile['nse_script']:
-            # Model for nse_script_combo_row is Gtk.FilterListModel -> Gtk.StringList
-            # We need to find profile['nse_script'] in the Gtk.StringList
-            string_list_model = self.nse_script_combo_row.get_model()
-            if isinstance(string_list_model, Gtk.FilterListModel):
-                string_list_model = string_list_model.get_model() # Get the underlying Gtk.StringList
-            
-            found_script = False
-            if isinstance(string_list_model, Gtk.StringList):
-                for i in range(string_list_model.get_n_items()):
-                    item_str = string_list_model.get_string(i)
-                    if item_str == profile['nse_script']:
-                        self.nse_script_combo_row.set_selected(i)
-                        # Important: also update self.selected_nse_script directly
-                        self.selected_nse_script = profile['nse_script']
-                        found_script = True
-                        break
-            if not found_script:
-                self.nse_script_combo_row.set_selected(0) # "None"
-                self.selected_nse_script = None
+            self.selected_timing_template = self.timing_options.get(list(self.timing_options.keys())[0])
         else:
-            self.nse_script_combo_row.set_selected(0) # "None"
-            self.selected_nse_script = None
+            self.os_fingerprint_switch.set_active(profile['os_fingerprint'])
+            self.stealth_scan_switch.set_active(profile['stealth_scan'])
+            self.no_ping_switch.set_active(profile['no_ping'])
+            self.port_spec_entry_row.set_text(profile['ports'])
+            self.arguments_entry_row.set_text(profile['additional_args'])
 
-        # Apply Timing Template
-        if profile['timing_template']:
-            # timing_options is {"Display Name": "Actual Nmap Arg", ...}
-            # profile['timing_template'] stores the "Actual Nmap Arg"
-            # We need to find the "Display Name" that corresponds to this arg.
-            target_timing_arg = profile['timing_template']
-            found_timing_display_name = None
-            for display_name, nmap_arg in self.timing_options.items():
-                if nmap_arg == target_timing_arg:
-                    found_timing_display_name = display_name
-                    break
-            
-            timing_model = self.timing_template_combo_row.get_model() # This is a Gtk.StringList
-            found_timing_in_model = False
-            if found_timing_display_name and isinstance(timing_model, Gtk.StringList):
-                for i in range(timing_model.get_n_items()):
-                    item_str = timing_model.get_string(i)
-                    if item_str == found_timing_display_name:
-                        self.timing_template_combo_row.set_selected(i)
-                        # Important: also update self.selected_timing_template
-                        self.selected_timing_template = target_timing_arg
-                        found_timing_in_model = True
-                        break
-            
-            if not found_timing_in_model: # Fallback to default if not found
-                self.timing_template_combo_row.set_selected(0) # "Default (T3)"
-                default_timing_display_name = list(self.timing_options.keys())[0]
-                self.selected_timing_template = self.timing_options[default_timing_display_name]
-        else: # No timing template in profile, set to default
-            self.timing_template_combo_row.set_selected(0) # "Default (T3)"
-            default_timing_display_name = list(self.timing_options.keys())[0]
-            self.selected_timing_template = self.timing_options[default_timing_display_name]
+            self.selected_nse_script = None 
+            if profile['nse_script']:
+                string_list_model = self.nse_script_combo_row.get_model()
+                if isinstance(string_list_model, Gtk.FilterListModel):
+                    string_list_model = string_list_model.get_model() 
+                if isinstance(string_list_model, Gtk.StringList):
+                    for i in range(string_list_model.get_n_items()):
+                        if string_list_model.get_string(i) == profile['nse_script']:
+                            self.nse_script_combo_row.set_selected(i)
+                            self.selected_nse_script = profile['nse_script']
+                            break
+            if not self.selected_nse_script and profile['nse_script']: 
+                self.nse_script_combo_row.set_selected(0)
+
+            self.selected_timing_template = self.timing_options.get(list(self.timing_options.keys())[0]) 
+            if profile['timing_template']:
+                target_timing_arg = profile['timing_template']
+                found_timing_display_name = next((dn for dn, arg in self.timing_options.items() if arg == target_timing_arg), None)
+                
+                timing_model = self.timing_template_combo_row.get_model()
+                if found_timing_display_name and isinstance(timing_model, Gtk.StringList):
+                    for i in range(timing_model.get_n_items()):
+                        if timing_model.get_string(i) == found_timing_display_name:
+                            self.timing_template_combo_row.set_selected(i)
+                            self.selected_timing_template = target_timing_arg
+                            break
+            if not self.selected_timing_template and profile['timing_template']: 
+                 self.timing_template_combo_row.set_selected(0)
             
         self._update_nmap_command_preview()
 
     def _add_target_to_history(self, target: str) -> None:
-        if not target or target.isspace():
-            return
-
-        # Normalize or clean the target string if needed (e.g., strip whitespace)
+        """Adds a target to the scan history and updates GSettings."""
         clean_target = target.strip()
+        if not clean_target: return
 
         if clean_target in self.target_history_list:
             self.target_history_list.remove(clean_target)
-        
-        self.target_history_list.insert(0, clean_target) # Add to the beginning
-
-        if len(self.target_history_list) > self.MAX_HISTORY_SIZE:
-            self.target_history_list = self.target_history_list[:self.MAX_HISTORY_SIZE]
-            
-        self.settings.set_strv("target-history", self.target_history_list)
+        self.target_history_list.insert(0, clean_target)
+        self.target_history_list = self.target_history_list[:self.MAX_HISTORY_SIZE]
+        self.settings.set_strv(self.TARGET_HISTORY_SCHEMA_KEY, self.target_history_list)
 
     def _on_target_history_changed(self, settings_obj: Gio.Settings, key_name: str) -> None:
-        # print("DEBUG: Target history GSetting changed, internal list updated.") # Modified print
+        """Updates internal target history list when GSettings change."""
         self.target_history_list = list(self.settings.get_strv(key_name))
-        # self.target_completion_model and self.target_completion no longer exist, so no model update here.
 
     def _initiate_scan_procedure(self) -> None:
-        """Core logic to start an Nmap scan based on current UI settings."""
-        target: str = self.target_entry_row.get_text().strip()
+        """Collects parameters and starts the Nmap scan in a worker thread."""
+        scan_params = self._get_current_scan_parameters()
+        target: str = scan_params["target"]
+
         if not target:
             self.toast_overlay.add_toast(Adw.Toast.new("Error: Target cannot be empty"))
             self._update_ui_state("ready", "Empty target")
             return
 
         self._add_target_to_history(target) 
-
         self._clear_results_ui()
         self._update_ui_state("scanning")
         self.toast_overlay.add_toast(Adw.Toast.new(f"Scan started for {target}"))
+        
+        # Prepare kwargs for _run_scan_worker, matching its signature
+        # _get_current_scan_parameters uses NmapScanner.scan keys, so map them
+        worker_kwargs = {
+            "target": scan_params["target"],
+            "do_os_fingerprint": scan_params["do_os_fingerprint"],
+            "additional_args_str": scan_params["additional_args_str"],
+            "nse_script": scan_params["nse_script"],
+            "stealth_scan": scan_params["stealth_scan"],
+            "port_spec_str": scan_params["port_spec"], # Map key
+            "timing_template_val": scan_params["timing_template"], # Map key
+            "do_no_ping_val": scan_params["no_ping"] # Map key
+        }
 
-        # TODO: Update args to include stealth_scan_switch.get_active() in a later step
-        scan_thread = threading.Thread(
-            target=self._run_scan_worker,
-            args=(
-                target,
-                self.os_fingerprint_switch.get_active(),
-                self.arguments_entry_row.get_text(),
-                self.stealth_scan_switch.get_active(),
-                self.port_spec_entry_row.get_text().strip(), # New
-                self.selected_timing_template,              # New
-                self.no_ping_switch.get_active()            # New
-            ),
-        )
+        scan_thread = threading.Thread(target=self._run_scan_worker, kwargs=worker_kwargs)
         scan_thread.daemon = True
         scan_thread.start()
 
     def _on_scan_button_clicked(self, entry: Adw.EntryRow) -> None:
-        """Callback for when the scan is initiated from the target entry row (e.g., pressing Enter)."""
+        """Handles scan initiation from the target entry row."""
         self._initiate_scan_procedure()
 
     def _on_start_scan_button_clicked(self, button: Gtk.Button) -> None:
-        """Callback for when the 'Start Scan' button is clicked."""
+        """Handles scan initiation from the 'Start Scan' button."""
         self._initiate_scan_procedure()
 
-    def _run_scan_worker(
-        self, target: str, do_os_fingerprint: bool, additional_args_str: str, do_stealth_scan: bool,
-        port_spec_str: Optional[str], timing_template_val: Optional[str], do_no_ping_val: bool # New
-    ) -> None:
-        """
-        Worker function to perform the Nmap scan.
-        This method is run in a separate thread.
-        """
-        # settings = Gio.Settings.new("com.github.mclellac.NetworkMap") # No longer needed here for default_args
-        # default_args_from_settings: str = settings.get_string("default-nmap-arguments") # Removed
-
+    def _run_scan_worker(self, target: str, do_os_fingerprint: bool, additional_args_str: str, 
+                         nse_script: Optional[str], stealth_scan: bool, port_spec_str: Optional[str], 
+                         timing_template_val: Optional[str], do_no_ping_val: bool) -> None:
+        """Worker function to perform Nmap scan (runs in a separate thread)."""
         error_type: Optional[str] = None
         error_message: Optional[str] = None
         hosts_data: Optional[List[Dict[str, Any]]] = None
 
         try:
             hosts_data, scan_message = self.nmap_scanner.scan(
-                target,
-                do_os_fingerprint,
-                additional_args_str,
-                self.selected_nse_script,
-                # default_args_str=default_args_from_settings, # Removed
-                stealth_scan=do_stealth_scan,
-                port_spec=port_spec_str,                # New
-                timing_template=timing_template_val,    # New
-                no_ping=do_no_ping_val                  # New
+                target=target,
+                do_os_fingerprint=do_os_fingerprint,
+                additional_args_str=additional_args_str,
+                nse_script=nse_script, 
+                stealth_scan=stealth_scan,
+                port_spec=port_spec_str, # Corrected key
+                timing_template=timing_template_val, # Corrected key
+                no_ping=do_no_ping_val # Corrected key
             )
-            if scan_message and not hosts_data:
-                error_type = "ScanMessage"
+            if scan_message and not hosts_data: 
+                error_type = "ScanMessage" 
                 error_message = scan_message
-
         except (NmapArgumentError, NmapScanParseError) as e:
             error_type = type(e).__name__
             error_message = str(e)
-        except Exception as e:
+        except Exception as e: 
             error_type = type(e).__name__
             error_message = f"An unexpected error occurred in the scan worker: {str(e)}"
 
         GLib.idle_add(self._process_scan_completion, hosts_data, error_type, error_message)
 
     def _process_scan_completion(
-        self,
-        hosts_data: Optional[List[Dict[str, Any]]],
-        error_type: Optional[str],
-        error_message: Optional[str],
+        self, hosts_data: Optional[List[Dict[str, Any]]], error_type: Optional[str], error_message: Optional[str]
     ) -> None:
         """Handles UI updates after the Nmap scan worker finishes."""
-        if error_type and error_message != "No hosts found.":
+        if error_type and error_message != "No hosts found.": 
+            self.current_scan_results = None
             self._display_scan_error(error_type, error_message or "Unknown error.")
             self._update_ui_state("error", error_message)
             self.toast_overlay.add_toast(Adw.Toast.new(f"Scan failed: {error_message or 'Unknown error'}"))
-            self.current_scan_results = None
-        elif hosts_data is not None and hosts_data:  # Scan successful with results
+        elif hosts_data:  
             self.current_scan_results = hosts_data
             self._populate_results_listbox(hosts_data)
-            # self._set_text_view_text("Select a host from the list to see its scan details.") # Obsolete
             self.status_page.set_property("description", "Scan Complete. Select a host to view details.")
             self._update_ui_state("success")
             self.toast_overlay.add_toast(Adw.Toast.new("Scan complete."))
-        elif hosts_data == [] or (error_type and error_message == "No hosts found."):
-            self._clear_results_ui()
-            if error_message == "No hosts found.": # Specific message from nmap_scanner
-                self.status_page.set_property("description", "Scan Complete: No hosts found.")
-            else: # General case for empty hosts_data
-                self.status_page.set_property("description", "Scan Complete: No hosts were found matching the criteria.")
-            self._update_ui_state("no_results") # This state already sets a generic "No hosts found"
-            self.toast_overlay.add_toast(Adw.Toast.new("Scan complete: No hosts found."))
+        elif error_type == "ScanMessage" and error_message == "No hosts found.": 
             self.current_scan_results = []
-        elif hosts_data is None and not error_type: # No data, no specific error
+            self._clear_results_ui()
+            self.status_page.set_property("description", "Scan Complete: No hosts found.")
+            self._update_ui_state("no_results")
+            self.toast_overlay.add_toast(Adw.Toast.new("Scan complete: No hosts found."))
+        elif not hosts_data and not error_type: 
+            self.current_scan_results = []
             self._clear_results_ui()
             self.status_page.set_property("description", "Scan Complete: No data received from scan.")
             self._update_ui_state("no_data")
             self.toast_overlay.add_toast(Adw.Toast.new("Scan complete: No data received."))
-            self.current_scan_results = None
-        # Fallback for any other unhandled error_type scenario that might not set hosts_data
-        elif error_type:
-             self._display_scan_error(error_type, error_message or "Unknown error.")
-             self._update_ui_state("error", error_message)
-             self.toast_overlay.add_toast(Adw.Toast.new(f"Scan failed: {error_message or 'An unspecified error occurred'}"))
+        else: 
              self.current_scan_results = None
-
-        # Correctly hide spinner and restore sensitivity
-        # This logic is now fully handled by the _update_ui_state method's else block.
-        # if self.spinner.get_visible(): # This is handled by _update_ui_state
-        #     self.spinner.set_visible(False)
-        # The following block is now redundant as _update_ui_state handles all widgets.
-        # if (
-        #     not self.target_entry_row.get_sensitive()
-        #     and self.status_page.get_property("description") != "Scanning..."
-        # ):
-        #     self.target_entry_row.set_sensitive(True)
-        #     self.arguments_entry_row.set_sensitive(True)
-        #     self.os_fingerprint_switch.set_sensitive(True)
-        pass # No specific action needed here anymore regarding widget sensitivity
+             self._display_scan_error(error_type or "UnknownError", error_message or "An unspecified error occurred.")
+             self._update_ui_state("error", error_message or "An unspecified error occurred.")
+             self.toast_overlay.add_toast(Adw.Toast.new(f"Scan failed: {error_message or 'An unspecified error occurred'}"))
+        
+        pass
 
     def _clear_results_ui(self) -> None:
-        """Clears the results listbox and the text view display."""
-        while child := self.results_listbox.get_row_at_index(0):
+        """Clears the results listbox."""
+        child = self.results_listbox.get_first_child()
+        while child:
             self.results_listbox.remove(child)
-        # self._set_text_view_text("") # Obsolete
+            child = self.results_listbox.get_first_child()
+
 
     def _populate_results_listbox(self, hosts_data: List[Dict[str, Any]]) -> None:
-        """Populates the results_listbox with discovered hosts from scan data."""
+        """Populates the results_listbox with discovered hosts."""
         for host_data in hosts_data:
-            raw_details = host_data.get("raw_details_text", "")
-            row = HostInfoExpanderRow(host_data=host_data, raw_details_text=raw_details)
-            # Apply font preference to the new row's text_view
-            if hasattr(self, 'font_css_provider'):
+            row = HostInfoExpanderRow(host_data=host_data, raw_details_text=host_data.get("raw_details_text", ""))
+            if hasattr(self, 'font_css_provider'): 
                  text_view = row.get_text_view()
                  if text_view:
                     text_view.get_style_context().add_provider(
-                        self.font_css_provider,
-                        Gtk.STYLE_PROVIDER_PRIORITY_USER
-                    )
+                        self.font_css_provider, Gtk.STYLE_PROVIDER_PRIORITY_USER)
             self.results_listbox.append(row)
-        # After populating, ensure font preferences are applied if rows were added.
-        # self._apply_font_preference() # This might be redundant if applied per row, but ensures consistency.
 
     def _display_scan_error(self, error_type: str, error_message: str) -> None:
         """Displays scan-related errors on the status page."""
         self._clear_results_ui()
-        # It's often better to use the specific error message if it's user-friendly,
-        # or a more generic one if it's too technical.
-        # For now, we'll combine them, but this could be refined.
-        friendly_message = f"Scan Error: {error_message}"
-        if error_type and error_type != "ScanMessage": # Avoid showing "Error Type: ScanMessage"
-             friendly_message = f"Error Type: {error_type}\nMessage: {error_message}"
-        
+        friendly_message = f"Scan Error ({error_type}): {error_message}" if error_type != "ScanMessage" else error_message
         self.status_page.set_property("description", friendly_message)
-        # Optionally, also log to console for debugging, or use a toast for less critical errors.
         print(f"Scan Error Displayed: Type={error_type}, Message={error_message}", file=sys.stderr)
 
-# Define HostInfoExpanderRow class
 class HostInfoExpanderRow(Adw.ExpanderRow):
     __gtype_name__ = "HostInfoExpanderRow"
 
@@ -649,58 +472,38 @@ class HostInfoExpanderRow(Adw.ExpanderRow):
         self.raw_details_text = raw_details_text
         self.set_title(host_data.get("hostname") or host_data.get("id", "Unknown Host"))
         self.set_subtitle(f"State: {host_data.get('state', 'N/A')}")
-        self.set_icon_name("computer-symbolic") # Keep icon consistent
+        self.set_icon_name("computer-symbolic") 
 
         self._text_view = Gtk.TextView(
-            editable=False,
-            cursor_visible=False,
-            wrap_mode=Gtk.WrapMode.WORD_CHAR,
-            vexpand=True, # Allow TextView to expand vertically
-            hexpand=True   # Allow TextView to expand horizontally
-        )
+            editable=False, cursor_visible=False, wrap_mode=Gtk.WrapMode.WORD_CHAR,
+            vexpand=True, hexpand=True )
         self._text_view.set_margin_top(6)
         self._text_view.set_margin_bottom(6)
         self._text_view.set_margin_start(6)
         self._text_view.set_margin_end(6)
         
-        # Apply initial font preference if available from the window
-        # This is a bit indirect, ideally the window would manage this centrally
         app_window = self.get_ancestor(NetworkMapWindow)
         if app_window and hasattr(app_window, 'font_css_provider'):
             self._text_view.get_style_context().add_provider(
-                app_window.font_css_provider,
-                Gtk.STYLE_PROVIDER_PRIORITY_USER
-            )
+                app_window.font_css_provider, Gtk.STYLE_PROVIDER_PRIORITY_USER)
 
-
-        frame = Gtk.Frame() # No label for the frame, details are implicit
+        frame = Gtk.Frame() 
         frame.set_child(self._text_view)
-        
-        # Add some padding or margin to the frame or textview if needed
-        # frame.set_margin_top(6)
-        # frame.set_margin_bottom(6)
-        # frame.set_margin_start(6)
-        # frame.set_margin_end(6)
-        
         self.add_row(frame)
         self.connect("notify::expanded", self._on_expanded_changed)
 
     def _on_expanded_changed(self, expander_row: Adw.ExpanderRow, pspec: GObject.ParamSpec) -> None:
         buffer = self._text_view.get_buffer()
         if expander_row.get_expanded():
-            buffer.set_text("")  # Clear existing content
+            buffer.set_text("") 
             markup_text = self.raw_details_text if self.raw_details_text else "<i>No additional details available.</i>"
-            try:
-                # The -1 argument for length means parse the whole string
+            try: 
                 buffer.insert_markup(buffer.get_end_iter(), markup_text, -1)
             except GLib.Error as e:
-                # Handle Pango parsing errors, e.g., log and set plain text
                 print(f"Pango markup error: {e}. Setting text plainly.", file=sys.stderr)
-                # Fallback to setting plain text, stripping any potential markup to be safe
-                plain_text_fallback = GLib.markup_escape_text(self.raw_details_text if self.raw_details_text else "No additional details available. (Markup error)")
+                plain_text_fallback = GLib.markup_escape_text(self.raw_details_text or "No additional details.")
                 buffer.set_text(plain_text_fallback)
         else:
-            # Optional: Clear buffer when collapsed
             buffer.set_text("") 
 
     def get_text_view(self) -> Optional[Gtk.TextView]:

--- a/tests/test_nmap_scanner.py
+++ b/tests/test_nmap_scanner.py
@@ -714,7 +714,9 @@ class TestNmapScannerPrivilegeExecution(unittest.TestCase):
         # -> "nmap --script 'http-title, \"safe space\"'" or similar.
         # Then, internal quotes are escaped: "nmap --script 'http-title, \\\"safe space\\\"'"
         expected_nmap_cmd_str = '/usr/local/bin/nmap -sS -p 80 localhost' # Simple case, no complex quoting by shlex.join
-        expected_applescript_cmd = f'do shell script "{expected_nmap_cmd_str.replace("\"", "\\\"")}" with administrator privileges'
+        # Correctly escape for AppleScript before inserting into f-string
+        processed_nmap_cmd_str = expected_nmap_cmd_str.replace('"', '\\"')
+        expected_applescript_cmd = f'do shell script "{processed_nmap_cmd_str}" with administrator privileges'
 
         self.scanner._execute_with_privileges(nmap_base, scan_args, target)
         
@@ -739,7 +741,9 @@ class TestNmapScannerPrivilegeExecution(unittest.TestCase):
         # Then replace('"', '\\"') makes it: /usr/local/bin/nmap --script-args 'http.useragent=\\\"My Nmap Agent 1.0\\\"' localhost
         # This seems correct for AppleScript's `do shell script "..."`
         joined_nmap_cmd = shlex.join(nmap_base + scan_args + [target])
-        expected_applescript_cmd = f'do shell script "{joined_nmap_cmd.replace("\"", "\\\"")}" with administrator privileges'
+        # Correctly escape for AppleScript before inserting into f-string
+        processed_nmap_cmd_str = joined_nmap_cmd.replace('"', '\\"')
+        expected_applescript_cmd = f'do shell script "{processed_nmap_cmd_str}" with administrator privileges'
 
         self.scanner._execute_with_privileges(nmap_base, scan_args, target)
         


### PR DESCRIPTION
This commit addresses your feedback requesting code cleanup, refactoring for maintainability, concise comments, and fixes for unit test failures that arose after initial refactoring.

Key changes made:

1.  NmapScanner Refactoring (`src/nmap_scanner.py`):
    *   `scan()` method: Logic for argument preparation (`_prepare_scan_args_list`) and privilege escalation assessment (`_should_escalate`) extracted into helper methods.
    *   `_execute_with_privileges()`: Comments refined for clarity.
    *   `build_scan_args()`: Comments refined.
    *   Nmap Path Logic: Escalation path logic consolidated into `_get_nmap_escalation_command_path()`.
    *   Error Handling: Ensured `scan()` correctly interprets `CompletedProcess` from `_execute_with_privileges`.
    *   `ROOT_REQUIRING_ARGS` updated to include `-O` for consistent OS detection privilege checks.

2.  Window UI Refactoring (`src/window.py`):
    *   Scan parameter collection centralized into `_get_current_scan_parameters()`.
    *   Comments reviewed and shortened.

3.  Utilities (`src/utils.py`):
    *   Comments reviewed for conciseness.

4.  Test Fixes (`tests/test_nmap_scanner.py`):
    *   Corrected a `SyntaxError` in f-string usage for AppleScript command construction.

Current Status & Known Issues:
*   `ImportError` in `tests/test_utils.py`: An `ImportError` related to `gi.repository.Adw` (imported in `src/utils.py` for the `apply_theme` function) persists. This prevents `tests/test_utils.py` from running successfully.
    *   Planned Next Step (not in this commit): Modify `src/utils.py` to make the import of `Adw` local to `apply_theme` and handle `ImportError` gracefully to allow testing of other utilities.
*   A full test run after addressing the `ImportError` is required.

Reason for submitting now:
This is the last turn available. The f-string syntax error in `tests/test_nmap_scanner.py` has been fixed. The next step would have been to address the `ImportError`.