### PR TITLE
Fix multiple UI and Flatpak issues

### DIFF
--- a/com.github.mclellac.NetworkMap.json
+++ b/com.github.mclellac.NetworkMap.json
@@ -10,7 +10,8 @@
 	"--socket=fallback-x11",
 	"--device=dri",
 	"--socket=wayland",
-	"--persist=.config"
+	"--persist=.config",
+	"--talk-name=org.freedesktop.PolicyKit1"
 	],
 	"cleanup" : [
 	"/include",

--- a/src/nmap_scanner.py
+++ b/src/nmap_scanner.py
@@ -180,7 +180,7 @@ class NmapScanner:
             elif is_flatpak():
                 # For Flatpak, flatpak-spawn --host is used with pkexec.
                 # The Nmap command and its arguments are passed directly.
-                escalation_cmd = ["flatpak-spawn", "--host", "pkexec"] + final_nmap_command_parts
+                escalation_cmd = ["flatpak-spawn", "--host", "pkexec", "nmap"] + scan_args_list + [target]
             elif is_linux(): # Covers non-Flatpak Linux
                 # For general Linux, pkexec is used.
                 escalation_cmd = ["pkexec"] + final_nmap_command_parts

--- a/src/profile_editor_dialog.py
+++ b/src/profile_editor_dialog.py
@@ -12,7 +12,9 @@ class ProfileEditorDialog(Adw.Dialog):
                  parent_window: Optional[Gtk.Window] = None, 
                  profile_to_edit: Optional[ScanProfile] = None, 
                  existing_profile_names: Optional[List[str]] = None):
-        super().__init__(transient_for=parent_window if parent_window else None, use_header_bar=True) # Adw.Dialog can use header bar
+        super().__init__()
+        if parent_window:
+            self.set_transient_for(parent_window)
             
         self.profile_to_edit = profile_to_edit
         self.is_editing = profile_to_edit is not None

--- a/src/utils.py
+++ b/src/utils.py
@@ -28,11 +28,15 @@ def discover_nse_scripts() -> List[str]:
     # Standard Nmap script directory locations for Linux/macOS.
     # Order matters: check user-specific paths first, then system paths.
     # Flatpak sandboxed paths are not directly accessible; Nmap inside Flatpak would use its own paths.
-    potential_paths = [
+    potential_paths = []
+    if is_flatpak():
+        potential_paths.append("/app/share/nmap/scripts/") # Add Flatpak path first
+
+    potential_paths.extend([
         os.path.expanduser("~/.nmap/scripts/"), # User's local Nmap scripts
         "/usr/local/share/nmap/scripts/",      # Common for locally compiled Nmap on macOS/Linux
         "/usr/share/nmap/scripts/",            # Standard system path for Nmap on Linux
-    ]
+    ])
     
     # For Flatpak, Nmap scripts are bundled within the Flatpak environment.
     # Accessing host system Nmap scripts from a sandboxed Flatpak app is generally not done.

--- a/src/window.py
+++ b/src/window.py
@@ -309,7 +309,7 @@ class NetworkMapWindow(Adw.ApplicationWindow):
         defaults = {
             'os_fingerprint': False, 'stealth_scan': False, 'no_ping': False,
             'ports': "", 'additional_args': "", 'nse_script': None,
-            'timing_template': self.timing_options.get(list(self.timing_options.keys())[0]) # Default T3
+            'timing_template': self.timing_options.get("Default (T3)")
         }
 
         config = profile if profile else defaults


### PR DESCRIPTION
This commit addresses several problems:

- TypeError in ProfileEditorDialog: Correctly initializes Adw.Dialog by setting transient_for after super().__init__() and removing unused use_header_bar.

- IndexError in NetworkMapWindow: Fixes an IndexError in _apply_scan_profile by safely retrieving the default timing template using a direct key lookup.

- Flatpak Nmap Privilege Escalation:
  - Modifies NmapScanner to ensure flatpak-spawn --host pkexec calls the host's 'nmap' command, not the sandboxed one.
  - Adds --talk-name=org.freedesktop.PolicyKit1 to Flatpak finish-args to allow communication with PolicyKit.

- Flatpak NSE Script Discovery: Updates discover_nse_scripts in utils.py to include /app/share/nmap/scripts/ in the search path when running as a Flatpak, allowing bundled NSE scripts to be listed.