### PR TITLE
Diagnose ProfileEditorDialog and improve logging

### DIFF
--- a/src/profile_editor_dialog.py
+++ b/src/profile_editor_dialog.py
@@ -12,8 +12,10 @@ class ProfileEditorDialog(Adw.Dialog):
                  parent_window: Optional[Gtk.Window] = None, 
                  profile_to_edit: Optional[ScanProfile] = None, 
                  existing_profile_names: Optional[List[str]] = None):
-        super().__init__(transient_for=parent_window if parent_window else None)
+        super().__init__()
             
+        # NO attempts to set transient-for here
+
         self.profile_to_edit = profile_to_edit
         self.is_editing = profile_to_edit is not None
         


### PR DESCRIPTION
This commit includes:
- A diagnostic change to ProfileEditorDialog: All attempts to set `transient_for` have been removed. This is to test if the dialog can be created without this property, bypassing a persistent TypeError. Dialog behavior regarding parent window interaction may be affected.
- Enhanced toast logging: Toast messages from Preferences and the Main Window are now also printed to sys.stderr to aid in debugging.