### PR TITLE
Fix: Use `set_size_request` for ProfileEditorDialog sizing

### DIFF
--- a/src/profile_editor_dialog.py
+++ b/src/profile_editor_dialog.py
@@ -25,7 +25,7 @@ class ProfileEditorDialog(Adw.Dialog):
             self.existing_profile_names_for_validation.remove(profile_to_edit['name'])
 
         self.set_title("Edit Scan Profile" if self.is_editing else "Add New Scan Profile")
-        self.set_default_size(500, 600) # Adjusted for potentially more content
+        self.set_size_request(500, 600)
 
         # Main content box for the dialog
         content_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12, 


### PR DESCRIPTION
Replaces the call to `self.set_default_size(500, 600)` with `self.set_size_request(500, 600)` in `ProfileEditorDialog.__init__`. This addresses an `AttributeError` where `set_default_size` was not found for `Adw.Dialog` instances, likely due to an issue with Python bindings or method exposure for this specific class. `set_size_request` is a standard Gtk.Widget method for suggesting initial widget dimensions.