### PR TITLE
Fix: Correct ProfileEditorDialog initialization

### DIFF
--- a/src/profile_editor_dialog.py
+++ b/src/profile_editor_dialog.py
@@ -12,7 +12,7 @@ class ProfileEditorDialog(Adw.Dialog):
                  parent_window: Optional[Gtk.Window] = None, 
                  profile_to_edit: Optional[ScanProfile] = None, 
                  existing_profile_names: Optional[List[str]] = None):
-        super().__init__()
+        Adw.Dialog.__init__(self) # Changed line
             
         # NO attempts to set transient-for here
 


### PR DESCRIPTION
Replaced `super().__init__()` with a direct call to `Adw.Dialog.__init__(self)` in the `ProfileEditorDialog` constructor.

This resolves a series of AttributeError issues (e.g., for `add_response`, `set_default_size`) that indicated the base Adw.Dialog class was not being fully initialized through the standard super() call in this specific environment or subclass context. Explicitly calling the parent's __init__ ensures the GObject is properly constructed, allowing its methods to be resolved.