### PR TITLE
Fix: Attempt deeper GObject initialization for ProfileEditorDialog

### DIFF
--- a/src/profile_editor_dialog.py
+++ b/src/profile_editor_dialog.py
@@ -12,7 +12,8 @@ class ProfileEditorDialog(Adw.Dialog):
                  parent_window: Optional[Gtk.Window] = None, 
                  profile_to_edit: Optional[ScanProfile] = None, 
                  existing_profile_names: Optional[List[str]] = None):
-        Adw.Dialog.__init__(self) # Changed line
+        GObject.Object.__init__(self) # Added/Changed line
+        super().__init__()            # Added/Changed line
             
         # NO attempts to set transient-for here
 


### PR DESCRIPTION
Replaces the previous Adw.Dialog initialization in ProfileEditorDialog.__init__ with an explicit call to GObject.Object.__init__(self) followed by super().__init__().

This is an attempt to resolve persistent AttributeError issues (e.g., for `add_response`) by ensuring the base GObject and the standard super() chain are both explicitly invoked. This addresses potential deep GObject initialization problems that were preventing the dialog from being correctly constructed.