### PR TITLE
Fix ProfileEditorDialog errors and implement functionality

### DIFF
--- a/src/preferences_window.py
+++ b/src/preferences_window.py
@@ -1,5 +1,5 @@
 import sys
-from gi.repository import Adw, Gtk, GObject, Gio, Pango
+from gi.repository import Adw, Gtk, GObject, Gio, Pango, GLib
 from typing import Optional
 
 from .utils import apply_theme
@@ -53,8 +53,9 @@ class NetworkMapPreferencesWindow(Adw.PreferencesWindow):
         self._load_and_display_profiles() # Initial population
 
     def _show_toast(self, message: str):
-        print(f"PREFERENCES TOAST: {message}", file=sys.stderr)
-        self.add_toast(Adw.Toast.new(message))
+        print(f"PREFERENCES TOAST: {message}", file=sys.stderr) # Keep original message for logging
+        escaped_message = GLib.markup_escape_text(message)
+        self.add_toast(Adw.Toast.new(escaped_message))
 
     def _init_settings_and_bindings(self) -> None:
         """Initializes GSettings and binds them to UI elements."""


### PR DESCRIPTION
Addresses multiple issues with the ProfileEditorDialog and related components:
- Corrected AttributeError by using Adw.Dialog's add_button instead of add_response.
- Resolved TypeError for unknown 'profile-action' signal by uncommenting its definition in ProfileEditorDialog.
- Fixed Gtk-WARNING for Pango markup errors in toasts by escaping messages in PreferencesWindow._show_toast.

Implemented full functionality in ProfileEditorDialog:
- Replaced minimal stub with a complete dialog for adding/editing scan profiles.
- UI includes Adw.EntryRows for profile name and Nmap arguments.
- Added "Save" (Gtk.ResponseType.APPLY) and "Cancel" (Gtk.ResponseType.CANCEL) buttons.
- Populates fields from existing profile data when editing.
- Emits 'profile-action' signal with 'save' and profile data, or 'cancel'.
- Includes validation for empty profile name and duplicate names.
- Dialog now remains open if its own validation fails, allowing you to correct input.
- Removed debug print statements from the minimal dialog version.

These changes make the profile management features in the preferences window functional.