### PR TITLE
Fix TypeError for transient_for in ProfileEditorDialog

### DIFF
--- a/src/profile_editor_dialog.py
+++ b/src/profile_editor_dialog.py
@@ -27,7 +27,13 @@ class ProfileEditorDialog(Adw.Dialog):
         # Given the history, let's try the explicit Adw.Dialog init again,
         # as the problem might not have been the init call itself but subsequent calls.
         
-        Adw.Dialog.__init__(self, transient_for=parent_window)
+        # Ensure other GObject initializations like GObject.Object.__init__(self) are removed 
+        # if they were workarounds, as super().__init__() should handle it for widgets.
+        super().__init__() # This calls the __init__ of Adw.Dialog
+        
+        # After the object is initialized by super().__init__(), then set properties.
+        if parent_window:
+            self.set_transient_for(parent_window)
         # If Adw.Dialog.__init__ fails, it will raise an exception and the object creation will stop,
         # which is standard behavior. No need for a broad try-except here.
 


### PR DESCRIPTION
I've corrected the initialization of ProfileEditorDialog to properly set the `transient_for` property. The previous method of passing `transient_for` as a keyword argument to `Adw.Dialog.__init__` caused a TypeError because the custom GObject was not set up to handle constructor keyword arguments for GObject properties.

The fix changes the initialization to:
1. Call `super().__init__()` to initialize the Adw.Dialog instance.
2. Subsequently call `self.set_transient_for(parent_window)` if a parent window is provided.

This is the standard GObject practice for setting properties after instance initialization and resolves the reported TypeError.