### PR TITLE
Fix AttributeError for transient_for in ProfileEditorDialog

### DIFF
--- a/src/profile_editor_dialog.py
+++ b/src/profile_editor_dialog.py
@@ -33,7 +33,7 @@ class ProfileEditorDialog(Adw.Dialog):
         
         # After the object is initialized by super().__init__(), then set properties.
         if parent_window:
-            self.set_transient_for(parent_window)
+            self.set_property("transient-for", parent_window)
         # If Adw.Dialog.__init__ fails, it will raise an exception and the object creation will stop,
         # which is standard behavior. No need for a broad try-except here.
 


### PR DESCRIPTION
Corrected ProfileEditorDialog initialization to use `self.set_property("transient-for", parent_window)` for setting dialog transiency.

The previous attempt to use `self.set_transient_for(parent_window)` resulted in an AttributeError, as this specific setter method was not available on the ProfileEditorDialog instance. Using the generic `set_property` method with the GObject property name "transient-for" is the correct way to set this property after the parent Adw.Dialog instance has been initialized via `super().__init__()`.

This resolves the AttributeError and ensures the dialog's transiency is set correctly.