### PR TITLE
Fix TypeError for unknown 'transient-for' property

### DIFF
--- a/src/profile_editor_dialog.py
+++ b/src/profile_editor_dialog.py
@@ -8,6 +8,8 @@ from typing import Optional # Keep for signature compatibility if needed by call
 # from .nse_script_selection_dialog import NseScriptSelectionDialog # Not needed for minimal
 
 class ProfileEditorDialog(Adw.Dialog):
+    __gtype_name__ = "ProfileEditorDialog"
+
     __gsignals__ = {
         'profile-action': (GObject.SignalFlags.RUN_FIRST, None, (str, GObject.TYPE_PYOBJECT))
     }


### PR DESCRIPTION
I resolved a TypeError in ProfileEditorDialog that occurred because the 'transient-for' property was not recognized on your custom dialog class. This was due to the class not being fully registered with the GObject type system.

The fix involves adding `__gtype_name__ = "ProfileEditorDialog"` to the ProfileEditorDialog class definition. This ensures that your custom class is properly registered as a GObject type, making all inherited properties from Adw.Dialog (including "transient-for") discoverable and settable via `self.set_property()`.

This allows `self.set_property("transient-for", parent_window)` to function correctly, resolving the "does not have property" TypeError and enabling the dialog's transiency to be set as you intended.