### PR TITLE
Fix transient_for property by passing to super().__init__

### DIFF
--- a/src/profile_editor_dialog.py
+++ b/src/profile_editor_dialog.py
@@ -14,14 +14,15 @@ class ProfileEditorDialog(Adw.Dialog):
                  parent_window: Optional[Gtk.Window] = None,
                  profile_to_edit: Optional[Dict[str, Any]] = None,
                  existing_profile_names: Optional[List[str]] = None):
-        super().__init__() # Initialize the Adw.Dialog parent class
+        
+        if parent_window:
+            super().__init__(transient_for=parent_window)
+        else:
+            super().__init__()
 
         self.profile_to_edit = profile_to_edit
         self.existing_profile_names = existing_profile_names if existing_profile_names else []
         self.original_profile_name = profile_to_edit['name'] if profile_to_edit else None
-
-        if parent_window:
-            self.set_transient_for(parent_window) # Set transiency
 
         if self.profile_to_edit:
             self.set_title("Edit Profile")


### PR DESCRIPTION
Corrected the ProfileEditorDialog initialization to set the 'transient-for' property by passing it as a keyword argument to `super().__init__()`.

Previous attempts to set this property via direct setters or `set_property` after initialization failed, indicating an issue with how the property was being accessed or when it was being set.

By passing `transient_for=parent_window` directly to `super().__init__()`, we leverage the GObject construction mechanism that handles property initialization from keyword arguments. This, in conjunction with the `__gtype_name__` attribute, should ensure the 'transient-for' property is correctly recognized and set.

This change aims to finally resolve the persistent AttributeError and TypeError related to setting the dialog's transiency.