### PR TITLE
I've corrected how ProfileEditorDialog (an Adw.Dialog subclass) is in…

### DIFF
--- a/src/preferences_window.py
+++ b/src/preferences_window.py
@@ -307,12 +307,11 @@ class NetworkMapPreferencesWindow(Adw.PreferencesWindow):
             self._show_toast(f"Could not load existing profiles to check names: {e}")
             all_profile_names = [] # Proceed with caution or disallow adding
         
-        dialog = ProfileEditorDialog(parent_window=self, existing_profile_names=all_profile_names)
+        dialog = ProfileEditorDialog(existing_profile_names=all_profile_names)
         dialog.connect("profile-action", self._handle_profile_dialog_action_add)
-        # dialog.present(self) # Adw.Dialog.present() doesn't take a parent argument like Gtk.Dialog.
-                               # For Adw.Dialog, transiency is set via set_transient_for().
-                               # Present it using its own present method without arguments.
-        dialog.present()
+        # Adw.Dialog.present() takes an optional Gtk.Window parent argument for transiency.
+        # This is the correct way to set the transient parent if not done during __init__ or via set_transient_for().
+        dialog.present(self)
 
 
     def _handle_profile_dialog_action_add(self, dialog: ProfileEditorDialog, action: str, profile_data: Optional[ScanProfile]) -> None:
@@ -337,14 +336,13 @@ class NetworkMapPreferencesWindow(Adw.PreferencesWindow):
             if profile_to_edit:
                 all_profile_names = [p['name'] for p in current_profiles]
                 dialog = ProfileEditorDialog(
-                    parent_window=self,
                     profile_to_edit=profile_to_edit,
                     existing_profile_names=all_profile_names
                 )
                 # Pass original_profile_name for context in the handler
                 dialog.connect("profile-action", self._handle_profile_dialog_action_edit, profile_name)
-                # dialog.present(self) # Adw.Dialog.present() issue as above
-                dialog.present()
+                # Adw.Dialog.present() takes an optional Gtk.Window parent argument for transiency.
+                dialog.present(self)
             else:
                 self._show_toast(f"Error: Profile '{profile_name}' not found for editing.")
         except (ProfileStorageError, Exception) as e: # Catch loading or other errors

--- a/src/profile_editor_dialog.py
+++ b/src/profile_editor_dialog.py
@@ -11,14 +11,10 @@ class ProfileEditorDialog(Adw.Dialog):
     }
 
     def __init__(self,
-                 parent_window: Optional[Gtk.Window] = None,
                  profile_to_edit: Optional[Dict[str, Any]] = None,
                  existing_profile_names: Optional[List[str]] = None):
         
-        if parent_window:
-            super().__init__(transient_for=parent_window)
-        else:
-            super().__init__()
+        super().__init__()
 
         self.profile_to_edit = profile_to_edit
         self.existing_profile_names = existing_profile_names if existing_profile_names else []


### PR DESCRIPTION
…stantiated and presented to resolve persistent errors related to the 'transient-for' property.

Key changes:
- I removed the `parent_window` parameter and all attempts to set `transient-for` (via constructor, setters, or set_property) from `ProfileEditorDialog.__init__`. Adw.Dialog does not have a 'transient-for' GObject property.
- I modified `PreferencesWindow` when creating and showing the `ProfileEditorDialog`:
    - The `parent_window` argument is no longer passed to the `ProfileEditorDialog` constructor.
    - The dialog is presented using `dialog.present(self)`, where `self` is the `NetworkMapPreferencesWindow`. This is the correct Adwaita API method to show a dialog and establish its relationship with the parent window.

This approach aligns with Libadwaita's intended use of Adw.Dialog and should ensure the dialog is correctly modal and parented.