### PR TITLE
I've fixed the default button for Adw.Dialog by using `set_default_wi…

### DIFF
--- a/src/profile_editor_dialog.py
+++ b/src/profile_editor_dialog.py
@@ -72,7 +72,7 @@ class ProfileEditorDialog(Adw.Dialog):
             # This might indicate a deeper structural issue if hit.
             print("Error: Dialog child is not a Gtk.Box, cannot append action_box.", file=sys.stderr)
         
-        self.set_default_response("apply") # This should still be called / was kept
+        self.set_default_widget(save_button) # Use the Gtk.Button instance directly
 
         self.connect("response", self._on_response)
         


### PR DESCRIPTION
…dget`.

I corrected `ProfileEditorDialog` to use `self.set_default_widget(save_button)` instead of the non-existent `self.set_default_response()` method, which was causing an `AttributeError`. `Adw.Dialog` inherits `set_default_widget` from `Gtk.Window`, and this is the correct way to specify the default action widget when buttons are manually added to the dialog.

Changes include:
- I replaced `self.set_default_response("apply")` with `self.set_default_widget(save_button)`, where `save_button` is the manually created `Gtk.Button` for the "Save" action.

This ensures the "Save" button is correctly designated as the default widget in the `ProfileEditorDialog`, resolving the `AttributeError`.