### PR TITLE
Here's a summary of the changes I've made to fix the Adw.Dialog respo…

### DIFF
--- a/src/profile_editor_dialog.py
+++ b/src/profile_editor_dialog.py
@@ -74,13 +74,13 @@ class ProfileEditorDialog(Adw.Dialog):
         
         self.set_default_widget(save_button) # Use the Gtk.Button instance directly
 
-        self.connect("response", self._on_response)
+        # self.connect("response", self._on_response) # Removed this line
         
         self.set_modal(True) # Make the dialog modal
         self.set_deletable(False) # Prevent closing via Esc key if validation is desired first
         self.set_size_request(400, -1) # Width, height can be auto
 
-    def _on_response(self, dialog: Adw.Dialog, response_id: str): # Changed type hint for response_id
+    def do_response(self, response_id: str): # Renamed and signature changed
         if response_id == "apply":
             name = self.profile_name_row.get_text().strip()
             command = self.profile_command_row.get_text().strip()


### PR DESCRIPTION
…nse handling:

I've corrected the `ProfileEditorDialog` to use an overridden `do_response` virtual method for managing dialog responses. This replaces the previous approach of trying to connect to a "response" GObject signal, which doesn't exist for Adw.Dialog (unlike Gtk.Dialog).

Here are the key changes:

*   I removed the line `self.connect("response", self._on_response)` from the `ProfileEditorDialog.__init__` method.
*   I renamed the `_on_response` method to `do_response(self, response_id: str)` and updated its signature to match the virtual method.
*   The logic for handling "apply" and "cancel" string response IDs, performing validation, and emitting the 'profile-action' custom signal is now located within the `do_response` method.
*   The manually added Gtk.Buttons for "Save" and "Cancel" will continue to call `self.response("apply")` and `self.response("cancel")` respectively. This will now correctly trigger the overridden `do_response` method.

This update aligns the dialog's response mechanism with the correct GObject pattern for Adw.Dialog and resolves the TypeError that was occurring due to the unknown "response" signal.