### PR TITLE
Remove redundant set_modal call in ProfileEditorDialog

### DIFF
--- a/src/profile_editor_dialog.py
+++ b/src/profile_editor_dialog.py
@@ -76,7 +76,6 @@ class ProfileEditorDialog(Adw.Dialog):
 
         # self.connect("response", self._on_response) # Removed this line
         
-        self.set_modal(True) # Make the dialog modal
         self.set_deletable(False) # Prevent closing via Esc key if validation is desired first
         self.set_size_request(400, -1) # Width, height can be auto
 


### PR DESCRIPTION
I removed the explicit call to `self.set_modal(True)` from the `__init__` method of `ProfileEditorDialog`.

Adw.Dialog (which ProfileEditorDialog subclasses) sets itself as modal by default in its own initialization. Therefore, the explicit call in the subclass was redundant and, more importantly, incorrect as `set_modal` is not an attribute of the Adw.Dialog instance itself (it's a Gtk.Window method, and Adw.Dialog is a Gtk.Widget).

This resolves the AttributeError related to 'set_modal' and relies on the default modal behavior of Adw.Dialog.