### PR TITLE
Fix dialog closability for Adw.Dialog using set_can_close

### DIFF
--- a/src/profile_editor_dialog.py
+++ b/src/profile_editor_dialog.py
@@ -76,7 +76,7 @@ class ProfileEditorDialog(Adw.Dialog):
 
         # self.connect("response", self._on_response) # Removed this line
         
-        self.set_deletable(False) # Prevent closing via Esc key if validation is desired first
+        self.set_can_close(False) # Prevent closing via Esc key/WM if validation is desired first
         self.set_size_request(400, -1) # Width, height can be auto
 
     def do_response(self, response_id: str): # Renamed and signature changed


### PR DESCRIPTION
I corrected ProfileEditorDialog to use self.set_can_close(False) instead of the non-existent self.set_deletable(False) method. Adw.Dialog inherits set_can_close from Adw.Window, and this is the correct way to control whether you can close the dialog via standard mechanisms like the Esc key or window manager buttons.

Changes include:
- Replaced `self.set_deletable(False)` with `self.set_can_close(False)` in ProfileEditorDialog.__init__().

This ensures the dialog's closability is managed correctly according to the Adw.Dialog API, preventing premature closure and resolving the AttributeError. Programmatic closing via dialog actions (Save/Cancel) remains unaffected.