### PR TITLE
Fix AttributeError for self.response in ProfileEditorDialog

### DIFF
--- a/src/profile_editor_dialog.py
+++ b/src/profile_editor_dialog.py
@@ -51,12 +51,12 @@ class ProfileEditorDialog(Adw.Dialog):
         action_box.set_halign(Gtk.Align.END) # Align buttons to the end (right)
 
         cancel_button = Gtk.Button(label="Cancel")
-        cancel_button.connect("clicked", lambda widget: self.response("cancel"))
+        cancel_button.connect("clicked", lambda widget: self.do_response("cancel"))
         action_box.append(cancel_button)
 
         save_button = Gtk.Button(label="Save")
         save_button.set_css_classes(["suggested-action"]) # Make it look like a suggested action
-        save_button.connect("clicked", lambda widget: self.response("apply"))
+        save_button.connect("clicked", lambda widget: self.do_response("apply"))
         action_box.append(save_button)
 
         # Append the action_box to the main_box of the dialog


### PR DESCRIPTION
Corrected how action button clicks trigger responses in ProfileEditorDialog. The "Save" and "Cancel" Gtk.Button instances now have their "clicked" signals connected to lambdas that directly call `self.do_response("apply")` and `self.do_response("cancel")` respectively.

Previously, the lambdas incorrectly attempted to call `self.response()`, which is not a public method on Adw.Dialog meant for this purpose, leading to an AttributeError. Adw.Dialog.response() is a C function that ultimately invokes the do_response virtual method. By calling our overridden do_response method directly, we achieve the intended behavior.

This resolves the AttributeError and ensures that the dialog's action logic (validation, signal emission, closing) is correctly executed when the buttons are clicked.