### PR TITLE
Revert to self.close() in ProfileEditorDialog do_response

### DIFF
--- a/src/profile_editor_dialog.py
+++ b/src/profile_editor_dialog.py
@@ -101,16 +101,16 @@ class ProfileEditorDialog(Adw.Dialog):
             print(f"DEBUG: apply - profile_data: {profile_data}", file=sys.stderr) # Print the data being saved
             print("DEBUG: apply - emitting profile-action 'save'", file=sys.stderr)
             self.emit("profile-action", "save", profile_data)
-            print("DEBUG: apply - calling self.destroy()", file=sys.stderr)
-            self.destroy()
-            print("DEBUG: apply - after self.destroy(), returning False", file=sys.stderr)
+            print("DEBUG: apply - calling self.close()", file=sys.stderr)
+            self.close()
+            print("DEBUG: apply - after self.close(), returning False", file=sys.stderr)
             return False # Explicitly return False after closing
         elif response_id == "cancel":
             print("DEBUG: cancel - emitting profile-action 'cancel'", file=sys.stderr)
             self.emit("profile-action", "cancel", None)
-            print("DEBUG: cancel - calling self.destroy()", file=sys.stderr)
-            self.destroy()
-            print("DEBUG: cancel - after self.destroy(), returning False", file=sys.stderr)
+            print("DEBUG: cancel - calling self.close()", file=sys.stderr)
+            self.close()
+            print("DEBUG: cancel - after self.close(), returning False", file=sys.stderr)
             return False # Explicitly return False after closing
         return False # Allow close for other cases or if not handled
 


### PR DESCRIPTION
I reverted the dialog closing mechanism in ProfileEditorDialog's do_response method from self.destroy() back to self.close().

My attempt to use self.destroy() resulted in an AttributeError. While self.close() was previously not visually closing the dialog for you (though logs showed it was called), it did not produce an AttributeError.

This change returns to self.close() to eliminate the AttributeError and allow for further investigation into why the dialog might not be visually closing as expected when self.close() is called. Debug prints remain in place to aid this.