### PR TITLE
I updated the `ProfileEditorDialog` to use `self.force_close()` for c…

### DIFF
--- a/src/profile_editor_dialog.py
+++ b/src/profile_editor_dialog.py
@@ -101,16 +101,16 @@ class ProfileEditorDialog(Adw.Dialog):
             print(f"DEBUG: apply - profile_data: {profile_data}", file=sys.stderr) # Print the data being saved
             print("DEBUG: apply - emitting profile-action 'save'", file=sys.stderr)
             self.emit("profile-action", "save", profile_data)
-            print("DEBUG: apply - calling self.close()", file=sys.stderr)
-            self.close()
-            print("DEBUG: apply - after self.close(), returning False", file=sys.stderr)
+            print("DEBUG: apply - calling self.force_close()", file=sys.stderr)
+            self.force_close()
+            print("DEBUG: apply - after self.force_close(), returning False", file=sys.stderr)
             return False # Explicitly return False after closing
         elif response_id == "cancel":
             print("DEBUG: cancel - emitting profile-action 'cancel'", file=sys.stderr)
             self.emit("profile-action", "cancel", None)
-            print("DEBUG: cancel - calling self.close()", file=sys.stderr)
-            self.close()
-            print("DEBUG: cancel - after self.close(), returning False", file=sys.stderr)
+            print("DEBUG: cancel - calling self.force_close()", file=sys.stderr)
+            self.force_close()
+            print("DEBUG: cancel - after self.force_close(), returning False", file=sys.stderr)
             return False # Explicitly return False after closing
         return False # Allow close for other cases or if not handled
 


### PR DESCRIPTION
…losing the dialog.

Previously, I was using `self.close()` and `self.destroy()`. I've now replaced those with `self.force_close()` in the `do_response` method for both the "apply" (save) and "cancel" actions.

According to the Adwaita documentation, `force_close()` is the recommended way to programmatically close an `Adw.Dialog`. This is particularly important when the dialog's 'can_close' property might be set to `False`, which is the case here to prevent you from accidentally dismissing it.

This change should ensure the dialog closes reliably after you save or cancel. I've also updated the debug print statements to reflect that `self.force_close()` is now being called.