### PR TITLE
Feat: Profile Editor UI Phases 1 & 2 - Host Discovery & Scan Techniques

### DIFF
--- a/tests/test_nmap_validator.py
+++ b/tests/test_nmap_validator.py
@@ -44,7 +44,14 @@ class TestNmapCommandValidator(unittest.TestCase):
             "-PU137-139",
             "-PS T:25,U:53",
             "-PS 22-25,80,T:110,U:161",
-            "-n --traceroute scanme.nmap.org"
+            "-n --traceroute scanme.nmap.org",
+            # Scan Technique Valid Cases
+            "-sS -sN localhost",
+            "-sU --traceroute target",
+            "-sA -PE scanme.nmap.org",
+            "-sW -Pn",
+            "-sM -T1",
+            "-sX -sV"
         ]
         for cmd_args in valid_cases:
             is_valid, msg = self.validator.validate_arguments(cmd_args)
@@ -82,6 +89,7 @@ class TestNmapCommandValidator(unittest.TestCase):
             if cmd_args == "-sV --foo": token = "--foo"
             if cmd_args == "-fjdskfjdshk": token = "-fjdskfjdshk"
             if cmd_args == "--gibberish-flag-123": token = "--gibberish-flag-123"
+            if cmd_args == "-sZ": token = "-sZ"
 
 
             self.assertFalse(is_valid, f"Expected invalid due to unknown option for command: '{cmd_args}'")


### PR DESCRIPTION
This commit implements Phase 1 and Phase 2 of the ProfileEditorDialog UI enhancements, adding categorized options for Host Discovery and Scan Techniques to aid in Nmap command construction.

Key Changes:

**Phase 1: Host Discovery Options & UI Structure**

ProfileEditorDialog (`src/profile_editor_dialog.py`):
- Restructured UI using Adw.ExpanderRow for categories: "General Scan Options", "Host Discovery", "Additional Manual Arguments".
- Added new Adwaita widgets to "Host Discovery" expander for:
    - -sL (List Scan), -sn (Ping Scan), -Pn (No Ping - relocated)
    - -PS[ports], -PA[ports], -PU[ports] (TCP SYN/ACK, UDP Ping + optional port entries)
    - -PE (ICMP Echo Ping)
    - -n (No DNS Resolution)
    - --traceroute (Traceroute)
- Implemented show/hide logic for optional port entries for -PS, -PA, -PU.
- Updated command construction (`do_response`) and parsing (`__init__`) to handle all new Host Discovery options and their arguments.

NmapCommandValidator (`src/nmap_validator.py` & tests):
- Added Host Discovery flags to `known_options`.
- Enhanced validation logic for -PS/PA/PU arguments (port lists).
- Updated/expanded unit tests for these changes.

**Phase 2: Scan Technique Options**

ProfileEditorDialog (`src/profile_editor_dialog.py`):
- Added "Scan Techniques" Adw.ExpanderRow.
- Added Adw.ComboRow for primary scan type selection (Default, -sS, -sT, -sU, -sA, -sW, -sM).
- Added Adw.SwitchRows for special TCP scans: -sN (Null), -sF (FIN), -sX (Xmas).
- Updated command construction and parsing to handle these new scan technique options.

NmapCommandValidator (`src/nmap_validator.py` & tests):
- Added Scan Technique flags to `known_options`.
- Updated unit tests to include and verify these scan technique flags.

This commit provides a significantly more organized and feature-rich ProfileEditorDialog, allowing you to configure a wider range of common Nmap options through a guided UI.