### PR TITLE
Fix: Prevent TypeError from passing None to set_text

### DIFF
--- a/src/profile_command_utils.py
+++ b/src/profile_command_utils.py
@@ -42,9 +42,14 @@ def parse_command_to_options(command_str: str) -> ProfileOptions:
         'tcp_ack_ping': False, 'udp_ping': False, 'icmp_echo_ping': False,
         'no_dns': False, 'traceroute': False, 'tcp_null_scan': False,
         'tcp_fin_scan': False, 'tcp_xmas_scan': False, 'version_detection': False,
-        'tcp_syn_ping_ports': None, 'tcp_ack_ping_ports': None, 'udp_ping_ports': None,
-        'primary_scan_type': None, 'ports': None, 'nse_script': None,
-        'timing_template': None, 'additional_args': ''
+        'tcp_syn_ping_ports': '', # Changed from None
+        'tcp_ack_ping_ports': '', # Changed from None
+        'udp_ping_ports': '',   # Changed from None
+        'primary_scan_type': None, # Remains None (used by ComboBox)
+        'ports': '',            # Changed from None
+        'nse_script': '',       # Changed from None (used by ComboBox, but good default for text)
+        'timing_template': None, # Remains None (used by ComboBox)
+        'additional_args': ''    # Remains ''
     }
 
     if not command_str:

--- a/src/window.py
+++ b/src/window.py
@@ -461,8 +461,8 @@ class NetworkMapWindow(Adw.ApplicationWindow):
             # This is okay; the command preview and scan will use these values from 'options'
             # when build_command_from_options is called (indirectly via NmapScanner).
 
-            self.port_spec_entry_row.set_text(options.get('ports', ''))
-            self.arguments_entry_row.set_text(options.get('additional_args', ''))
+            self.port_spec_entry_row.set_text(options.get('ports') or '')
+            self.arguments_entry_row.set_text(options.get('additional_args') or '')
 
             # Timing Template
             selected_timing_value = options.get('timing_template')


### PR DESCRIPTION
This commit addresses a TypeError that occurred when applying a scan profile if an Optional[str] field in ProfileOptions was None.

Changes:
- Modified `window.py` in `_apply_scan_profile` to use `options.get(key) or ''` when calling `set_text()` for Adw.EntryRow widgets. This ensures an empty string is passed instead of None.
- Modified `profile_command_utils.py` in `parse_command_to_options` to initialize several text-based Optional[str] fields in the ProfileOptions dictionary to `''` (empty string) instead of `None`. This provides a safer default for UI elements expecting strings.
- Reviewed `ProfileEditorDialog` to ensure consistent handling of optional text fields.

These changes make the application more robust when handling profiles that may not define all possible text-based Nmap options.