### PR TITLE
Fix: Use correct API for Adw.AlertDialog in ProfileEditorDialog

### DIFF
--- a/src/profile_editor_dialog.py
+++ b/src/profile_editor_dialog.py
@@ -353,8 +353,8 @@ class ProfileEditorDialog(Adw.Dialog):
         print(f"PROFILE EDITOR INFO (will be AlertDialog): {message}", file=sys.stderr) # Keep for console logging
 
         alert_dialog = Adw.AlertDialog(heading="Input Error", body=message)
-        alert_dialog.add_button(label="OK") # Response is "default"
-        alert_dialog.set_default_response("default")
+        alert_dialog.add_response("ok", "OK") # Use add_response with an ID and label
+        alert_dialog.set_default_response("ok") # Set the default response to the added ID
         alert_dialog.set_transient_for(self) # 'self' is ProfileEditorDialog
         alert_dialog.set_modal(True)
         alert_dialog.present()


### PR DESCRIPTION
Replaces the incorrect use of `add_button()` with `add_response()` for `Adw.AlertDialog` in the `_show_alert_dialog` method of `ProfileEditorDialog`.

The `add_button()` method is not an attribute of `Adw.AlertDialog`. The correct way to add an action/button is `add_response(id, label)`. The default response was also updated to use the specified response ID.

This resolves an `AttributeError` that occurred when trying to display an alert (e.g., for an empty profile name) in the profile editor.