### PR TITLE
Fix: Resolve config import error and trim comments

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1,2 +1,1 @@
-# src/config.py
 DEBUG_ENABLED = False

--- a/src/main.py
+++ b/src/main.py
@@ -163,7 +163,6 @@ def main(argv: Optional[List[str]] = None) -> int:
     Returns:
         The exit status of the application.
     """
-    # Use current sys.argv if argv is None
     current_argv = argv if argv is not None else sys.argv
 
     parser = argparse.ArgumentParser(description="Network Map application")
@@ -179,7 +178,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         config.DEBUG_ENABLED = True
 
     if config.DEBUG_ENABLED:
-        print("DEBUG: Debug mode enabled.") # Initial confirmation if debug is on
+        print("DEBUG: Debug mode enabled.")
 
     # Pass remaining arguments (plus program name) to app.run()
     # GTK application typically expects sys.argv format

--- a/src/meson.build
+++ b/src/meson.build
@@ -40,6 +40,7 @@ networkmap_sources = [
   'profile_manager.py',
   'utils.py',
   'window.py',
+  'config.py' # Added config.py
 ]
 
 py_installation.install_sources(

--- a/src/nmap_scanner.py
+++ b/src/nmap_scanner.py
@@ -15,6 +15,7 @@ import sys
 import shutil 
 from typing import Tuple, Optional, List, Dict, Any
 from .utils import is_root, is_macos, is_linux, is_flatpak 
+from .config import DEBUG_ENABLED
 
 
 class NmapArgumentError(ValueError):
@@ -93,8 +94,9 @@ class NmapScanner:
             timing_template=timing_template,
             no_ping=no_ping
         )
-        # print(f"DEBUG_PROFILE_TRACE: NmapScanner._prepare_scan_args_list - Built scan_args_str: '{scan_args_str}'")
-        # print(f"DEBUG_PROFILE_TRACE: NmapScanner._prepare_scan_args_list - Inputs to build_scan_args were: do_os_fingerprint={do_os_fingerprint}, additional_args_str='{additional_args_str}', nse_script='{nse_script}', gsettings_default_args='{gsettings_default_args}', stealth_scan={stealth_scan}, port_spec='{port_spec}', timing_template='{timing_template}', no_ping={no_ping}")
+        if DEBUG_ENABLED:
+            print(f"DEBUG_PROFILE_TRACE: NmapScanner._prepare_scan_args_list - Built scan_args_str: '{scan_args_str}'")
+            print(f"DEBUG_PROFILE_TRACE: NmapScanner._prepare_scan_args_list - Inputs to build_scan_args were: do_os_fingerprint={do_os_fingerprint}, additional_args_str='{additional_args_str}', nse_script='{nse_script}', gsettings_default_args='{gsettings_default_args}', stealth_scan={stealth_scan}, port_spec='{port_spec}', timing_template='{timing_template}', no_ping={no_ping}")
 
         current_scan_args_list: List[str] = []
         try:
@@ -224,7 +226,8 @@ class NmapScanner:
         timing_template: Optional[str] = None,
         no_ping: bool = False
     ) -> Tuple[Optional[List[Dict[str, Any]]], Optional[str]]:
-        # print(f"DEBUG_PROFILE_TRACE: NmapScanner.scan - Received parameters: target='{target}', os_fingerprint={do_os_fingerprint}, additional_args_str='{additional_args_str}', nse_script='{nse_script}', stealth_scan={stealth_scan}, port_spec='{port_spec}', timing_template='{timing_template}', no_ping={no_ping}")
+        if DEBUG_ENABLED:
+            print(f"DEBUG_PROFILE_TRACE: NmapScanner.scan - Received parameters: target='{target}', os_fingerprint={do_os_fingerprint}, additional_args_str='{additional_args_str}', nse_script='{nse_script}', stealth_scan={stealth_scan}, port_spec='{port_spec}', timing_template='{timing_template}', no_ping={no_ping}")
         
         try:
             current_scan_args_list, scan_args_str_for_direct_scan = self._prepare_scan_args_list(
@@ -340,7 +343,8 @@ class NmapScanner:
         GSettings defaults, user-provided additional arguments, and UI-selected options.
         Returns a string representation suitable for `nmap.PortScanner().scan()`.
         """
-        # print(f"DEBUG_PROFILE_TRACE: NmapScanner.build_scan_args - Input parameters: do_os_fingerprint={do_os_fingerprint}, additional_args_str='{additional_args_str}', nse_script='{nse_script}', default_args_str='{default_args_str}', stealth_scan={stealth_scan}, port_spec='{port_spec}', timing_template='{timing_template}', no_ping={no_ping}")
+        if DEBUG_ENABLED:
+            print(f"DEBUG_PROFILE_TRACE: NmapScanner.build_scan_args - Input parameters: do_os_fingerprint={do_os_fingerprint}, additional_args_str='{additional_args_str}', nse_script='{nse_script}', default_args_str='{default_args_str}', stealth_scan={stealth_scan}, port_spec='{port_spec}', timing_template='{timing_template}', no_ping={no_ping}")
         if not isinstance(additional_args_str, str):
             raise NmapArgumentError("Additional arguments must be a string.")
 
@@ -380,7 +384,8 @@ class NmapScanner:
         # 4. Apply GSettings-based DNS arguments
         self._apply_gsettings_dns_arg(final_args_list)
 
-        # print(f"DEBUG_PROFILE_TRACE: NmapScanner.build_scan_args - Final constructed args list (before join): {final_args_list}")
+        if DEBUG_ENABLED:
+            print(f"DEBUG_PROFILE_TRACE: NmapScanner.build_scan_args - Final constructed args list (before join): {final_args_list}")
         # Use shlex.join for proper quoting of arguments
         return shlex.join(final_args_list)
 
@@ -670,7 +675,7 @@ class NmapScanner:
 
         # Extract and print scan statistics for debugging/info
         scan_stats = self.nm.scanstats()
-        if scan_stats:
+        if scan_stats and DEBUG_ENABLED:
             stats_str = f"Scan stats: {scan_stats.get('uphosts', 'N/A')} up, {scan_stats.get('downhosts', 'N/A')} down, {scan_stats.get('totalhosts', 'N/A')} total. Elapsed: {scan_stats.get('elapsed', 'N/A')}s."
             print(f"DEBUG Nmap Scan Stats: {stats_str}", file=sys.stderr)
         

--- a/src/nmap_validator.py
+++ b/src/nmap_validator.py
@@ -149,7 +149,7 @@ class NmapCommandValidator:
                             for char_fn in filename_forbidden_chars:
                                 if char_fn in arg_value:
                                     return False, f"Filename argument for {part} ('{arg_value}') contains forbidden character: '{char_fn}'."
-                        i += 1 # Consume the argument for options_with_args
+                        i += 1
 
                     elif part in ["-PS", "-PA", "-PU"]: # Optional space-separated argument
                         if (i + 1) < len(parts) and not parts[i+1].startswith("-"):
@@ -158,9 +158,9 @@ class NmapCommandValidator:
                                 port_regex = re.compile(r"^(?:[TU]:)?(?:[0-9]{1,5}(?:-[0-9]{1,5})?)(?:,(?:[TU]:)?(?:[0-9]{1,5}(?:-[0-9]{1,5})?))*$")
                                 if not port_regex.fullmatch(port_arg):
                                     return False, f"Invalid port specification format for {part}: '{port_arg}'."
-                            i += 1 # Consume validated argument
+                            i += 1
                         # If no argument or next is an option, it's fine (-PS alone is valid)
-            i += 1 # Consume the option part itself or a non-option part
+            i += 1
         return True, ""
 
 

--- a/src/nse_script_selection_dialog.py
+++ b/src/nse_script_selection_dialog.py
@@ -35,21 +35,17 @@ class NseScriptSelectionDialog(Adw.Dialog):
         if current_scripts_str:
             self.current_selected_scripts = set(s.strip() for s in current_scripts_str.split(',') if s.strip())
 
-        # Main layout box
         main_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12, margin_top=12, margin_bottom=12, margin_start=12, margin_end=12)
         self.set_child(main_box)
 
-        # Scrolled window for the list of scripts
         scrolled_window = Gtk.ScrolledWindow(has_frame=True, policy=(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC), vexpand=True)
         main_box.append(scrolled_window)
 
-        # ListBox to hold script rows
         self.list_box = Gtk.ListBox(selection_mode=Gtk.SelectionMode.NONE)
         scrolled_window.set_child(self.list_box)
 
         self.check_buttons: dict[str, Gtk.CheckButton] = {} # Stores script_name: Gtk.CheckButton
 
-        # Populate list with predefined NSE scripts
         for display_name, script_name in PREDEFINED_NSE_SCRIPTS:
             row = Adw.ActionRow(title=display_name)
             check_button = Gtk.CheckButton(active=(script_name in self.current_selected_scripts))
@@ -59,7 +55,6 @@ class NseScriptSelectionDialog(Adw.Dialog):
             row.set_activatable_widget(check_button) # Allows toggling by clicking the row
             self.list_box.append(row)
 
-        # Action buttons (Cancel, Select)
         action_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6, halign=Gtk.Align.END, margin_top=12)
         
         cancel_button = Gtk.Button(label="Cancel")

--- a/src/preferences_window.py
+++ b/src/preferences_window.py
@@ -3,6 +3,7 @@ from gi.repository import Adw, Gtk, GObject, Gio, Pango, GLib
 from typing import Optional
 
 from .utils import apply_theme
+from .config import DEBUG_ENABLED
 from .profile_manager import (
     ProfileManager, ScanProfile,
     ProfileNotFoundError, ProfileExistsError, ProfileStorageError
@@ -50,7 +51,8 @@ class NetworkMapPreferencesWindow(Adw.PreferencesWindow):
         self._load_and_display_profiles() # Initial population
 
     def _show_toast(self, message: str):
-        print(f"PREFERENCES TOAST: {message}", file=sys.stderr) # Keep original message for logging
+        if DEBUG_ENABLED:
+            print(f"PREFERENCES TOAST: {message}", file=sys.stderr)
         escaped_message = GLib.markup_escape_text(message)
         self.add_toast(Adw.Toast.new(escaped_message))
 
@@ -180,7 +182,8 @@ class NetworkMapPreferencesWindow(Adw.PreferencesWindow):
                         # Handle errors specifically raised by ProfileManager (e.g., file not found, JSON error)
                         self._show_toast(f"Import failed: {e}")
                     except Exception as e: # Catch any other unexpected errors during the process
-                        print(f"Unexpected error during profile import: {e}", file=sys.stderr) # Log for debugging
+                        # Keep this print as it's for unexpected errors, not routine debug tracing
+                        print(f"Unexpected error during profile import: {e}", file=sys.stderr)
                         self._show_toast("An unexpected error occurred during import.")
                 else: # Should not happen if gfile is valid, but as a safeguard
                      self._show_toast("Failed to get file path for import.")
@@ -213,7 +216,8 @@ class NetworkMapPreferencesWindow(Adw.PreferencesWindow):
                         # Handle errors specifically raised by ProfileManager (e.g., file write error)
                         self._show_toast(f"Export failed: {e}")
                     except Exception as e: # Catch any other unexpected errors
-                        print(f"Unexpected error during profile export: {e}", file=sys.stderr) # Log for debugging
+                        # Keep this print as it's for unexpected errors
+                        print(f"Unexpected error during profile export: {e}", file=sys.stderr)
                         self._show_toast("An unexpected error occurred during export.")
                 else: # Safeguard
                     self._show_toast("Failed to get file path for export.")
@@ -223,7 +227,6 @@ class NetworkMapPreferencesWindow(Adw.PreferencesWindow):
 
     def _load_and_display_profiles(self) -> None:
         """Clears and re-populates the profiles list box from storage."""
-        # Clear existing rows
         while (child := self.profiles_list_box.get_row_at_index(0)) is not None:
             self.profiles_list_box.remove(child)
         

--- a/src/profile_command_utils.py
+++ b/src/profile_command_utils.py
@@ -42,14 +42,14 @@ def parse_command_to_options(command_str: str) -> ProfileOptions:
         'tcp_ack_ping': False, 'udp_ping': False, 'icmp_echo_ping': False,
         'no_dns': False, 'traceroute': False, 'tcp_null_scan': False,
         'tcp_fin_scan': False, 'tcp_xmas_scan': False, 'version_detection': False,
-        'tcp_syn_ping_ports': '', # Changed from None
-        'tcp_ack_ping_ports': '', # Changed from None
-        'udp_ping_ports': '',   # Changed from None
-        'primary_scan_type': None, # Remains None (used by ComboBox)
-        'ports': '',            # Changed from None
-        'nse_script': '',       # Changed from None (used by ComboBox, but good default for text)
-        'timing_template': None, # Remains None (used by ComboBox)
-        'additional_args': ''    # Remains ''
+        'tcp_syn_ping_ports': '',
+        'tcp_ack_ping_ports': '',
+        'udp_ping_ports': '',
+        'primary_scan_type': None,
+        'ports': '',
+        'nse_script': '',
+        'timing_template': None,
+        'additional_args': ''
     }
 
     if not command_str:
@@ -95,7 +95,7 @@ def parse_command_to_options(command_str: str) -> ProfileOptions:
         elif part == "-p":
             if i + 1 < len(parts) and not parts[i+1].startswith("-"):
                 options['ports'] = parts[i+1]
-                i += 1 # Consume argument
+                i += 1
             else: # -p without argument or followed by another option
                 remaining_parts.append(part) # Treat as unparsed for now
         elif part == "--script":

--- a/src/profile_manager.py
+++ b/src/profile_manager.py
@@ -41,7 +41,7 @@ class ProfileManager:
             raise ProfileStorageError(f"Failed to load profiles from GSettings: {e}") from e
 
         profiles: List[ScanProfile] = []
-        malformed_entries_details = [] # Store details of malformed entries
+        malformed_entries_details = []
 
         for i, json_str in enumerate(profiles_json):
             try:
@@ -51,7 +51,7 @@ class ProfileManager:
                     continue
                 
                 profile_name = profile_data.get('name')
-                profile_command = profile_data.get('command') # Get the command
+                profile_command = profile_data.get('command')
 
                 if not profile_name or not isinstance(profile_name, str):
                     malformed_entries_details.append(f"Entry at index {i} has missing or invalid 'name': {json_str[:100]}")
@@ -128,9 +128,8 @@ class ProfileManager:
                ProfileExistsError: If `updated_profile_data['name']` (the new name) conflicts with another existing profile's name.
                ProfileStorageError: If underlying storage fails.
         """
-        profiles = self.load_profiles() # Load current profiles
+        profiles = self.load_profiles()
         
-        # Find the index of the profile to update
         profile_index_to_update = -1
         for i, p in enumerate(profiles):
             if p['name'] == profile_name:
@@ -140,9 +139,8 @@ class ProfileManager:
         if profile_index_to_update == -1:
             raise ProfileNotFoundError(f"Profile with name '{profile_name}' not found and cannot be updated.")
 
-        # If the name is being changed, check for conflicts with other profiles' names
         new_profile_name = updated_profile_data['name']
-        if new_profile_name != profile_name: # Name is changing
+        if new_profile_name != profile_name:
             if any(p['name'] == new_profile_name for idx, p in enumerate(profiles) if idx != profile_index_to_update):
                 raise ProfileExistsError(f"Cannot rename profile to '{new_profile_name}' as another profile with this name already exists.")
             
@@ -176,13 +174,12 @@ class ProfileManager:
                                     serializing profiles, or writing to the file.
         """
         try:
-            profiles_to_export = self.load_profiles() # Load current profiles from GSettings
+            profiles_to_export = self.load_profiles()
             
             # Serialize the list of profiles to a JSON string
             # indent=4 makes the JSON file human-readable
             json_data_to_export = json.dumps(profiles_to_export, indent=4)
             
-            # Write the JSON string to the specified file
             with open(filepath, 'w', encoding='utf-8') as f:
                 f.write(json_data_to_export)
         except FileNotFoundError: # More specific for the case where the directory path doesn't exist
@@ -225,7 +222,7 @@ class ProfileManager:
         if not isinstance(imported_data_list, list):
             raise ProfileStorageError("Invalid import file format: Expected a JSON list of profiles.")
 
-        current_profiles = self.load_profiles() # Load existing profiles
+        current_profiles = self.load_profiles()
         existing_profile_names = {p['name'] for p in current_profiles}
         
         imported_count = 0

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,6 +1,6 @@
 import os
 import sys 
-from typing import List, Tuple # Added Tuple for type hint
+from typing import List, Tuple
 import logging
 
 from gi.repository import Adw
@@ -74,10 +74,9 @@ def discover_nse_scripts() -> List[str]:
     try:
         for item_name in os.listdir(scripts_directory):
             if item_name.endswith(".nse") and os.path.isfile(os.path.join(scripts_directory, item_name)):
-                script_name_no_ext = item_name[:-4] # Remove .nse
+                script_name_no_ext = item_name[:-4]
                 
                 assigned_category = DEFAULT_CATEGORY
-                # Attempt to categorize based on prefixes
                 for prefix in SCRIPT_PREFIXES:
                     if script_name_no_ext.startswith(prefix + '-') or \
                        script_name_no_ext.startswith(prefix + '_') or \
@@ -90,15 +89,14 @@ def discover_nse_scripts() -> List[str]:
         # Sort by category (prefix alphabetical), then by script name within each category.
         categorized_scripts.sort() 
         
-        # Extract just the script names, now sorted
         final_script_names = [name for category, name in categorized_scripts]
 
     except OSError as e:
-        logging.error(f"Error reading NSE script directory {scripts_directory}: {e}") # Changed to error
-        return [] # Return empty list on error
+        logging.error(f"Error reading NSE script directory {scripts_directory}: {e}")
+        return []
 
     if not final_script_names:
-        logging.info(f"No NSE scripts found in {scripts_directory}.") # Info if dir was found but no scripts
+        logging.info(f"No NSE scripts found in {scripts_directory}.")
         
     return final_script_names
 


### PR DESCRIPTION
This commit addresses two main items:
1.  Fixes an `ImportError` related to the new `config.py` module.
    - `src/main.py` now correctly imports and modifies `config.DEBUG_ENABLED`.
    - Other modules (`window.py`, `nmap_scanner.py`, etc.) import `DEBUG_ENABLED` directly from `src.config`.
    - This makes the `--debug` flag functional.

2.  Trims and removes low-value or redundant comments across various Python files in the `src/` directory.
    - Self-explanatory comments were removed.
    - Verbose comments were shortened where possible without losing essential context.
    - Comments explaining complex logic, design decisions, or non-obvious behaviors were retained.
    - This improves overall code readability and maintainability.