### PR TITLE
Fix: Reinstate and ensure conditional debug logging

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -139,7 +139,7 @@ class NetworkMapWindow(Adw.ApplicationWindow):
         is_valid = True
         if ports_text:
             is_valid, error_message = self.validator.validate_arguments(f"-p {ports_text}")
-            if not is_valid and DEBUG_ENABLED: # Made this conditional
+            if not is_valid and DEBUG_ENABLED:
                  print(f"DEBUG Ports Entry Error: {error_message} for input '{ports_text}'", file=sys.stderr)
         if not is_valid and ports_text:
             if "error" not in self.port_spec_entry_row.get_css_classes():
@@ -157,74 +157,83 @@ class NetworkMapWindow(Adw.ApplicationWindow):
         if string_list_model.get_n_items() > 0:
             self.profile_combo_row.set_selected(0)
         else:
-            print("Warning: Profile combo box is empty after population.", file=sys.stderr) # Keep as warning
+            print("Warning: Profile combo box is empty after population.", file=sys.stderr)
 
     def _on_profile_selected(self, combo_row: Adw.ComboRow, pspec: GObject.ParamSpec) -> None:
-        # if DEBUG_ENABLED: print(f"DEBUG_PROFILE_TRACE: _on_profile_selected - Handler ENTERED.")
+        if DEBUG_ENABLED: print(f"DEBUG_PROFILE_TRACE: _on_profile_selected - Handler ENTERED.")
+
         selected_idx = combo_row.get_selected()
         model = combo_row.get_model()
-        # if DEBUG_ENABLED: print(f"DEBUG_PROFILE_TRACE: _on_profile_selected - selected_idx: {selected_idx}, model type: {type(model)}")
+
+        if DEBUG_ENABLED: print(f"DEBUG_PROFILE_TRACE: _on_profile_selected - selected_idx: {selected_idx}, model type: {type(model)}")
+
         effective_model = None
         if isinstance(model, Gtk.StringList):
             effective_model = model
         elif isinstance(model, Gtk.FilterListModel):
             underlying_model = model.get_model()
-            # if DEBUG_ENABLED: print(f"DEBUG_PROFILE_TRACE: _on_profile_selected - Model is FilterListModel, underlying model type: {type(underlying_model)}")
+            if DEBUG_ENABLED: print(f"DEBUG_PROFILE_TRACE: _on_profile_selected - Model is FilterListModel, underlying model type: {type(underlying_model)}")
             if isinstance(underlying_model, Gtk.StringList):
                 effective_model = underlying_model
             else:
-                # if DEBUG_ENABLED: print(f"DEBUG_PROFILE_TRACE: _on_profile_selected - Exiting: Underlying model of FilterListModel is not StringList.")
+                if DEBUG_ENABLED: print(f"DEBUG_PROFILE_TRACE: _on_profile_selected - Exiting: Underlying model of FilterListModel is not StringList.")
                 return
         else:
-            # if DEBUG_ENABLED: print(f"DEBUG_PROFILE_TRACE: _on_profile_selected - Exiting: Model is not StringList or FilterListModel with StringList.")
-            # if DEBUG_ENABLED and model is None: print(f"DEBUG_PROFILE_TRACE: _on_profile_selected - Model is None.")
+            if DEBUG_ENABLED: print(f"DEBUG_PROFILE_TRACE: _on_profile_selected - Exiting: Model is not StringList or FilterListModel with StringList.")
+            if DEBUG_ENABLED and model is None: print(f"DEBUG_PROFILE_TRACE: _on_profile_selected - Model is None.")
             return
+
         if selected_idx < 0 :
-            # if DEBUG_ENABLED: print(f"DEBUG_PROFILE_TRACE: _on_profile_selected - Exiting: selected_idx is {selected_idx} (invalid list position or no selection).")
-             return
+            if DEBUG_ENABLED: print(f"DEBUG_PROFILE_TRACE: _on_profile_selected - Exiting: selected_idx is {selected_idx} (invalid list position or no selection).")
+            return
+
         selected_name = effective_model.get_string(selected_idx)
-        # if DEBUG_ENABLED: print(f"DEBUG_PROFILE_TRACE: _on_profile_selected - Selected name from model: '{selected_name}'")
+        if DEBUG_ENABLED: print(f"DEBUG_PROFILE_TRACE: _on_profile_selected - Selected name from model: '{selected_name}'")
+
         if selected_idx == 0 and selected_name == "Manual Configuration":
-            # if DEBUG_ENABLED: print(f"DEBUG_PROFILE_TRACE: _on_profile_selected - Applying 'Manual Configuration'.")
+            if DEBUG_ENABLED: print(f"DEBUG_PROFILE_TRACE: _on_profile_selected - Applying 'Manual Configuration'.")
             self._apply_scan_profile(None) 
         else:
             profile_name_to_find = selected_name
-            # if DEBUG_ENABLED: print(f"DEBUG_PROFILE_TRACE: _on_profile_selected - Searching for profile: '{profile_name_to_find}'")
+            if DEBUG_ENABLED: print(f"DEBUG_PROFILE_TRACE: _on_profile_selected - Searching for profile: '{profile_name_to_find}'")
+
             profiles = []
             try:
                 profiles = self.profile_manager.load_profiles()
-                # if DEBUG_ENABLED:
-                #     profile_names_loaded = [p.get('name', 'UnknownName') for p in profiles]
-                #     print(f"DEBUG_PROFILE_TRACE: _on_profile_selected - Loaded profiles from manager: {profile_names_loaded}")
+                if DEBUG_ENABLED:
+                    profile_names_loaded = [p.get('name', 'UnknownName') for p in profiles]
+                    print(f"DEBUG_PROFILE_TRACE: _on_profile_selected - Loaded profiles from manager: {profile_names_loaded}")
             except Exception as e:
-                # if DEBUG_ENABLED: print(f"DEBUG_PROFILE_TRACE: _on_profile_selected - Error loading profiles: {e}")
+                if DEBUG_ENABLED: print(f"DEBUG_PROFILE_TRACE: _on_profile_selected - Error loading profiles: {e}")
                 if self.profile_combo_row.get_selected() != 0:
                     self.profile_combo_row.set_selected(0)
                 else:
                     self._apply_scan_profile(None)
                 return
+
             found_profile = next((p for p in profiles if p.get('name') == profile_name_to_find), None)
+
             if found_profile:
-                # if DEBUG_ENABLED:
-                #     profile_name_found = found_profile.get('name', 'UnknownName')
-                #     profile_command_found = found_profile.get('command', 'NoCommand')
-                #     print(f"DEBUG_PROFILE_TRACE: _on_profile_selected - Profile FOUND: name='{profile_name_found}', command='{profile_command_found}'")
+                if DEBUG_ENABLED:
+                    profile_name_found = found_profile.get('name', 'UnknownName')
+                    profile_command_found = found_profile.get('command', 'NoCommand')
+                    print(f"DEBUG_PROFILE_TRACE: _on_profile_selected - Profile FOUND: name='{profile_name_found}', command='{profile_command_found}'")
                 self._apply_scan_profile(found_profile)
-                # if DEBUG_ENABLED:
-                #     print(f"DEBUG_PROFILE_TRACE: _on_profile_selected (after apply) - arguments_entry_row text: '{self.arguments_entry_row.get_text()}'")
-                #     print(f"DEBUG_PROFILE_TRACE: _on_profile_selected (after apply) - selected_nse_script: '{self.selected_nse_script}'")
-                #     print(f"DEBUG_PROFILE_TRACE: _on_profile_selected (after apply) - selected_timing_template: '{self.selected_timing_template}'")
-                #     print(f"DEBUG_PROFILE_TRACE: _on_profile_selected (after apply) - os_fingerprint_switch: {self.os_fingerprint_switch.get_active()}")
-                #     print(f"DEBUG_PROFILE_TRACE: _on_profile_selected (after apply) - stealth_scan_switch: {self.stealth_scan_switch.get_active()}")
-                #     print(f"DEBUG_PROFILE_TRACE: _on_profile_selected (after apply) - no_ping_switch: {self.no_ping_switch.get_active()}")
-                #     print(f"DEBUG_PROFILE_TRACE: _on_profile_selected (after apply) - port_spec_entry_row: '{self.port_spec_entry_row.get_text()}'")
+                if DEBUG_ENABLED:
+                    print(f"DEBUG_PROFILE_TRACE: _on_profile_selected (after apply) - arguments_entry_row text: '{self.arguments_entry_row.get_text()}'")
+                    print(f"DEBUG_PROFILE_TRACE: _on_profile_selected (after apply) - selected_nse_script: '{self.selected_nse_script}'")
+                    print(f"DEBUG_PROFILE_TRACE: _on_profile_selected (after apply) - selected_timing_template: '{self.selected_timing_template}'")
+                    print(f"DEBUG_PROFILE_TRACE: _on_profile_selected (after apply) - os_fingerprint_switch: {self.os_fingerprint_switch.get_active()}")
+                    print(f"DEBUG_PROFILE_TRACE: _on_profile_selected (after apply) - stealth_scan_switch: {self.stealth_scan_switch.get_active()}")
+                    print(f"DEBUG_PROFILE_TRACE: _on_profile_selected (after apply) - no_ping_switch: {self.no_ping_switch.get_active()}")
+                    print(f"DEBUG_PROFILE_TRACE: _on_profile_selected (after apply) - port_spec_entry_row: '{self.port_spec_entry_row.get_text()}'")
             else: 
-                # if DEBUG_ENABLED: print(f"DEBUG_PROFILE_TRACE: _on_profile_selected - Profile NOT found by name: '{profile_name_to_find}'. Reverting to Manual Configuration.")
+                if DEBUG_ENABLED: print(f"DEBUG_PROFILE_TRACE: _on_profile_selected - Profile NOT found by name: '{profile_name_to_find}'. Reverting to Manual Configuration.")
                 if self.profile_combo_row.get_selected() != 0:
                     self.profile_combo_row.set_selected(0)
                 else:
                      self._apply_scan_profile(None)
-        # if DEBUG_ENABLED: print(f"DEBUG_PROFILE_TRACE: _on_profile_selected - Handler EXITED.")
+        if DEBUG_ENABLED: print(f"DEBUG_PROFILE_TRACE: _on_profile_selected - Handler EXITED.")
 
     def _populate_timing_template_combo(self) -> None:
         self.timing_options = {
@@ -287,9 +296,9 @@ class NetworkMapWindow(Adw.ApplicationWindow):
                     css_rules.append(f"font-size: {size_points}pt;")
                 if css_rules:
                     css_data = f"* {{ {' '.join(css_rules)} }}".encode()
-            except GLib.Error as e: # Keep this as it's a real error
+            except GLib.Error as e:
                 print(f"Error parsing font string '{font_str}' with Pango: {e}. CSS will not be applied.", file=sys.stderr)
-            except Exception as e: # Keep this as it's a real error
+            except Exception as e:
                 print(f"An unexpected error occurred while parsing font string '{font_str}': {e}. CSS will not be applied.", file=sys.stderr)
         self.font_css_provider.load_from_data(css_data)
         child = self.results_listbox.get_first_child()
@@ -314,7 +323,7 @@ class NetworkMapWindow(Adw.ApplicationWindow):
         self.nse_script_combo_row.set_model(filter_model)
         if filter_model.get_n_items() > 0:
             self.nse_script_combo_row.set_selected(0)
-        else: # Keep as warning
+        else:
             print("Warning: NSE script combo box is empty after population.", file=sys.stderr)
 
 
@@ -327,7 +336,7 @@ class NetworkMapWindow(Adw.ApplicationWindow):
             self.selected_nse_script = None
         else:
             self.selected_nse_script = None
-            if DEBUG_ENABLED: # Made this conditional
+            if DEBUG_ENABLED:
                 print(f"Debug: Unexpected item type in NSE script combo: {type(selected_item)}", file=sys.stderr)
         self._update_nmap_command_preview()
         self._update_ui_state("ready")
@@ -495,7 +504,7 @@ class NetworkMapWindow(Adw.ApplicationWindow):
 
     def _initiate_scan_procedure(self) -> None:
         scan_params = self._get_current_scan_parameters()
-        # if DEBUG_ENABLED: print(f"DEBUG_PROFILE_TRACE: _initiate_scan_procedure - scan_params collected: {scan_params}")
+        if DEBUG_ENABLED: print(f"DEBUG_PROFILE_TRACE: _initiate_scan_procedure - scan_params collected: {scan_params}")
         target: str = scan_params["target"]
         if not target:
             self._show_toast("Error: Target cannot be empty")
@@ -527,7 +536,7 @@ class NetworkMapWindow(Adw.ApplicationWindow):
     def _run_scan_worker(self, target: str, do_os_fingerprint: bool, additional_args_str: str, 
                          nse_script: Optional[str], stealth_scan: bool, port_spec_str: Optional[str], 
                          timing_template_val: Optional[str], do_no_ping_val: bool) -> None:
-        # if DEBUG_ENABLED: print(f"DEBUG_PROFILE_TRACE: _run_scan_worker - Received parameters: target='{target}', os={do_os_fingerprint}, additional_args='{additional_args_str}', nse='{nse_script}', stealth={stealth_scan}, ports='{port_spec_str}', timing='{timing_template_val}', no_ping={do_no_ping_val}")
+        if DEBUG_ENABLED: print(f"DEBUG_PROFILE_TRACE: _run_scan_worker - Received parameters: target='{target}', os={do_os_fingerprint}, additional_args='{additional_args_str}', nse='{nse_script}', stealth={stealth_scan}, ports='{port_spec_str}', timing='{timing_template_val}', no_ping={do_no_ping_val}")
         scan_result: Dict[str, Any] = {
             "hosts_data": None, "error_type": None, "error_message": None, "scan_message": None
         }
@@ -550,7 +559,7 @@ class NetworkMapWindow(Adw.ApplicationWindow):
         except Exception as e:
             scan_result["error_type"] = "UnexpectedError"
             scan_result["error_message"] = f"An unexpected error occurred: {str(e)}"
-            import traceback # Keep this for unexpected errors
+            import traceback
             print(traceback.format_exc(), file=sys.stderr)
         GLib.idle_add(self._process_scan_completion, scan_result)
 
@@ -616,7 +625,7 @@ class NetworkMapWindow(Adw.ApplicationWindow):
         self._clear_results_ui()
         friendly_message = f"Scan Error ({error_type}): {error_message}" if error_type != "ScanMessage" else error_message
         self.status_page.set_property("description", friendly_message)
-        if DEBUG_ENABLED: # Made this conditional
+        if DEBUG_ENABLED:
             print(f"Scan Error Displayed: Type={error_type}, Message={error_message}", file=sys.stderr)
 
 class HostInfoExpanderRow(Adw.ExpanderRow):
@@ -651,7 +660,7 @@ class HostInfoExpanderRow(Adw.ExpanderRow):
             markup_text = self.raw_details_text if self.raw_details_text else "<i>No additional details available.</i>"
             try: 
                 buffer.insert_markup(buffer.get_end_iter(), markup_text, -1)
-            except GLib.Error as e: # Keep this as it's a real error
+            except GLib.Error as e:
                 print(f"Pango markup error: {e}. Setting text plainly.", file=sys.stderr)
                 plain_text_fallback = GLib.markup_escape_text(self.raw_details_text or "No additional details.")
                 buffer.set_text(plain_text_fallback)


### PR DESCRIPTION
This commit ensures that all previously added "DEBUG_PROFILE_TRACE" and other debug-specific print statements are uncommented and correctly conditionalized based on the `DEBUG_ENABLED` flag (set by the `--debug` command-line argument).

Changes were verified in:
- `src/window.py` (especially `_on_profile_selected`, `_initiate_scan_procedure`, `_run_scan_worker`, and other debug prints).
- `src/nmap_scanner.py` (methods `scan`, `_prepare_scan_args_list`, `build_scan_args`, and `_parse_scan_results`).
- `src/profile_editor_dialog.py` and `src/preferences_window.py` for their respective debug helper prints.

This resolves an issue where debug logs were unintentionally left commented out or were not correctly activated by the `--debug` flag, hindering troubleshooting efforts. The detailed trace logging should now be available when running the application with `--debug`.