### PR TITLE
Feature: Add extensive debug logging

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1,1 +1,2 @@
 DEBUG_ENABLED = False
+# print(f"DEBUG: config.DEBUG_ENABLED initialized to {DEBUG_ENABLED}") # Cannot print here as it runs on import

--- a/src/networkmap.in
+++ b/src/networkmap.in
@@ -24,15 +24,29 @@ site_packages_path = os.path.join('/usr/local/lib', python_version, 'site-packag
 if site_packages_path not in sys.path:
     sys.path.insert(0, site_packages_path)
 
+# Attempt to import config early for debug flags.
+# This assumes 'networkmap' is in the path, which it should be due to the above.
+try:
+    from networkmap import config
+except ImportError:
+    # Fallback if config cannot be imported, debug messages will not be conditional here.
+    # This might happen if script is run in a weird environment or before full package setup.
+    class DummyConfig:
+        DEBUG_ENABLED = False # Default to False if config is not available
+    config = DummyConfig()
+
 # --- BEGIN Adwaita Import Test ---
-print("DEBUG: Attempting direct import of Adwaita...", file=sys.stderr)
+if config.DEBUG_ENABLED:
+    print("DEBUG: Attempting direct import of Adwaita...", file=sys.stderr)
 try:
     import gi
     gi.require_version("Adw", "1")
     from gi.repository import Adw
-    print("DEBUG: Direct import of Adwaita (Adw) SUCCEEDED.", file=sys.stderr)
+    if config.DEBUG_ENABLED:
+        print("DEBUG: Direct import of Adwaita (Adw) SUCCEEDED.", file=sys.stderr)
 except Exception as e_adw_test:
-    print(f"DEBUG: Direct import of Adwaita (Adw) FAILED: {type(e_adw_test).__name__}: {e_adw_test}", file=sys.stderr)
+    if config.DEBUG_ENABLED:
+        print(f"DEBUG: Direct import of Adwaita (Adw) FAILED: {type(e_adw_test).__name__}: {e_adw_test}", file=sys.stderr)
 # --- END Adwaita Import Test ---
 
 # 2. Load GResources
@@ -42,10 +56,12 @@ try:
     resource_path = conf['RESOURCE_PATH']
 
     if os.path.exists(resource_path):
-        print(f"INFO: Attempting to load resource from: {resource_path}", file=sys.stderr)
+        if config.DEBUG_ENABLED:
+            print(f"INFO: Attempting to load resource from: {resource_path}", file=sys.stderr)
         resource = Gio.Resource.load(resource_path)
         Gio.resources_register(resource)
-        print(f"INFO: Successfully loaded and registered resources from: {resource_path}", file=sys.stderr)
+        if config.DEBUG_ENABLED:
+            print(f"INFO: Successfully loaded and registered resources from: {resource_path}", file=sys.stderr)
     else:
         print(f"ERROR: Compiled GResource file not found at {resource_path}. Application may fail to load UI.", file=sys.stderr)
 

--- a/src/nmap_validator.py
+++ b/src/nmap_validator.py
@@ -1,8 +1,12 @@
 import re
 import sys
+from .config import DEBUG_ENABLED # Import DEBUG_ENABLED
+from .utils import _get_arg_value_reprs # Import the helper
 
 class NmapCommandValidator:
     def __init__(self):
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Entering {self.__class__.__name__}.__init__(args: self)")
         self.forbidden_chars = [";", "|", "&", "$", "`", "(", ")", "<", ">", "\n", "\r"]
 
         # Common Nmap options
@@ -52,6 +56,8 @@ class NmapCommandValidator:
         # Options that can have arguments directly appended (e.g., -T4)
         # For these, the main parser might not see a separate arg, so we must recognize them.
         self.prefix_options = {"-T"} # -T0, -T1, ..., -T5 are distinct, but -T is a prefix
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}.__init__")
 
 
     def validate_arguments(self, command_args_str: str) -> tuple[bool, str]:
@@ -66,9 +72,15 @@ class NmapCommandValidator:
             is_valid is True if arguments are considered valid, False otherwise.
             error_message contains a description of the validation failure if any.
         """
+        if DEBUG_ENABLED:
+            arg_str = _get_arg_value_reprs(self, command_args_str)
+            print(f"DEBUG: Entering {self.__class__.__name__}.validate_arguments(args: {arg_str})")
+
         # 1. Overall check for forbidden characters (shell injection, etc.)
         for char in self.forbidden_chars:
             if char in command_args_str:
+                if DEBUG_ENABLED:
+                    print(f"DEBUG: Exiting {self.__class__.__name__}.validate_arguments (Validation Fail: Forbidden char '{char}')")
                 return False, f"Command arguments contain forbidden character: '{char}'."
 
         parts = command_args_str.split()
@@ -160,6 +172,9 @@ class NmapCommandValidator:
                             i += 1
                         # If no argument or next is an option, it's fine (-PS alone is valid)
             i += 1
+
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}.validate_arguments (Validation OK)")
         return True, ""
 
 

--- a/src/nse_script_selection_dialog.py
+++ b/src/nse_script_selection_dialog.py
@@ -1,5 +1,7 @@
 from gi.repository import Adw, Gtk, GObject
 from typing import List, Optional
+from .config import DEBUG_ENABLED # Import DEBUG_ENABLED
+from .utils import _get_arg_value_reprs # Import the helper
 
 # A predefined list of common NSE scripts with a display name and script name
 # (display_name, script_name_for_nmap)
@@ -22,6 +24,9 @@ class NseScriptSelectionDialog(Adw.Dialog):
     }
 
     def __init__(self, parent_window: Optional[Gtk.Window] = None, current_scripts_str: Optional[str] = None):
+        if DEBUG_ENABLED:
+            arg_str = _get_arg_value_reprs(self, parent_window=parent_window, current_scripts_str=current_scripts_str)
+            print(f"DEBUG: Entering {self.__class__.__name__}.__init__(args: {arg_str})")
         super().__init__()
 
         if parent_window:
@@ -66,13 +71,23 @@ class NseScriptSelectionDialog(Adw.Dialog):
         action_box.append(select_button)
         
         main_box.append(action_box)
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}.__init__")
 
     def _on_cancel_clicked(self, button: Gtk.Button) -> None:
         """Handles the Cancel button click event."""
+        if DEBUG_ENABLED:
+            arg_str = _get_arg_value_reprs(self, button)
+            print(f"DEBUG: Entering {self.__class__.__name__}._on_cancel_clicked(args: {arg_str})")
         self.close()
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._on_cancel_clicked")
 
     def _on_select_clicked(self, button: Gtk.Button) -> None:
         """Handles the Select button click event, emitting selected scripts."""
+        if DEBUG_ENABLED:
+            arg_str = _get_arg_value_reprs(self, button)
+            print(f"DEBUG: Entering {self.__class__.__name__}._on_select_clicked(args: {arg_str})")
         selected_scripts_list = [
             script_name for script_name, check_button in self.check_buttons.items() if check_button.get_active()
         ]
@@ -86,6 +101,10 @@ class NseScriptSelectionDialog(Adw.Dialog):
         # Using a set then list ensures uniqueness if custom scripts could duplicate checked ones.
         # For now, only predefined scripts are handled, so direct list comprehension is fine.
         final_scripts_str = ",".join(sorted(list(set(selected_scripts_list))))
+        if DEBUG_ENABLED:
+            print(f"DEBUG: {self.__class__.__name__}._on_select_clicked - Emitting scripts-selected with: {final_scripts_str}")
 
         self.emit("scripts-selected", final_scripts_str)
         self.close()
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._on_select_clicked")

--- a/src/preferences_window.py
+++ b/src/preferences_window.py
@@ -2,7 +2,7 @@ import sys
 from gi.repository import Adw, Gtk, GObject, Gio, Pango, GLib
 from typing import Optional
 
-from .utils import apply_theme
+from .utils import apply_theme, _get_arg_value_reprs
 from .config import DEBUG_ENABLED
 from .profile_manager import (
     ProfileManager, ScanProfile,
@@ -31,6 +31,8 @@ class NetworkMapPreferencesWindow(Adw.PreferencesWindow):
     import_profiles_button: Gtk.Button = Gtk.Template.Child("import_profiles_button")
 
     def __init__(self, parent_window: Optional[Gtk.Window] = None):
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Entering {self.__class__.__name__}.__init__(args: self, parent_window={repr(parent_window)})")
         super().__init__(transient_for=parent_window if parent_window else None)
         self.settings = Gio.Settings.new("com.github.mclellac.NetworkMap")
         self.profile_manager = ProfileManager()
@@ -38,14 +40,19 @@ class NetworkMapPreferencesWindow(Adw.PreferencesWindow):
         self._init_ui_components()
         self._connect_signals()
         self._load_and_display_profiles()
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}.__init__")
 
     def _show_toast(self, message: str):
+        # Existing DEBUG_ENABLED check is fine for the print itself.
         if DEBUG_ENABLED:
             print(f"PREFERENCES TOAST: {message}", file=sys.stderr)
         escaped_message = GLib.markup_escape_text(message)
         self.add_toast(Adw.Toast.new(escaped_message))
 
     def _init_settings_and_bindings(self) -> None:
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Entering {self.__class__.__name__}._init_settings_and_bindings(args: self)")
         font_str = self.settings.get_string("results-font")
         if font_str:
             try:
@@ -62,18 +69,31 @@ class NetworkMapPreferencesWindow(Adw.PreferencesWindow):
         self.settings.bind(
             "default-nmap-arguments", self.pref_default_nmap_args_entry_row, "text", Gio.SettingsBindFlags.DEFAULT
         )
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._init_settings_and_bindings")
 
     def _init_ui_components(self) -> None:
-        pass
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Entering {self.__class__.__name__}._init_ui_components(args: self)")
+        # Method is currently empty
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._init_ui_components")
 
     def _connect_signals(self) -> None:
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Entering {self.__class__.__name__}._connect_signals(args: self)")
         self.pref_font_button.connect("font-set", self._on_font_changed)
         self.pref_theme_combo_row.connect("notify::selected", self._on_theme_changed)
         self.add_profile_button.connect("clicked", self._on_add_profile_clicked)
         self.export_profiles_button.connect("clicked", self._on_export_profiles_clicked)
         self.import_profiles_button.connect("clicked", self._on_import_profiles_clicked)
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._connect_signals")
 
     def _init_font_settings(self) -> None:
+        # This method seems unused, but adding logs if it were.
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Entering {self.__class__.__name__}._init_font_settings(args: self)")
         font_str = self.settings.get_string("results-font")
         if font_str:
             try:
@@ -82,25 +102,45 @@ class NetworkMapPreferencesWindow(Adw.PreferencesWindow):
             except GLib.Error as e:
                 print(f"Error setting font from GSettings: {e}", file=sys.stderr)
         self.pref_font_button.connect("font-set", self._on_font_changed)
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._init_font_settings")
 
     def _init_theme_settings(self) -> None:
+        # This method seems unused, but adding logs if it were.
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Entering {self.__class__.__name__}._init_theme_settings(args: self)")
         theme_str = self.settings.get_string("theme")
         selected_theme_index = self.THEME_MAP_GSETTINGS_TO_INDEX.get(theme_str, 0)
         self.pref_theme_combo_row.set_selected(selected_theme_index)
         self.pref_theme_combo_row.connect("notify::selected", self._on_theme_changed)
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._init_theme_settings")
 
     def _bind_gsettings(self) -> None:
+        # This method seems unused, but adding logs if it were.
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Entering {self.__class__.__name__}._bind_gsettings(args: self)")
         self.settings.bind(
             "dns-servers", self.pref_dns_servers_entry_row, "text", Gio.SettingsBindFlags.DEFAULT
         )
         self.settings.bind(
             "default-nmap-arguments", self.pref_default_nmap_args_entry_row, "text", Gio.SettingsBindFlags.DEFAULT
         )
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._bind_gsettings")
 
     def _init_profile_management_ui(self) -> None:
-        pass
+        # This method seems unused, but adding logs if it were.
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Entering {self.__class__.__name__}._init_profile_management_ui(args: self)")
+        # Method is currently empty
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._init_profile_management_ui")
 
     def _create_file_chooser(self, title: str, action: Gtk.FileChooserAction, accept_label: str) -> Gtk.FileChooserNative:
+        if DEBUG_ENABLED:
+            arg_str = _get_arg_value_reprs(self, title, action, accept_label)
+            print(f"DEBUG: Entering {self.__class__.__name__}._create_file_chooser(args: {arg_str})")
         file_chooser = Gtk.FileChooserNative.new(
             title=title, parent=self.get_root(), action=action,
             accept_label=accept_label, cancel_label="_Cancel"
@@ -110,16 +150,26 @@ class NetworkMapPreferencesWindow(Adw.PreferencesWindow):
         json_filter.add_mime_type("application/json")
         json_filter.add_pattern("*.json")
         file_chooser.add_filter(json_filter)
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._create_file_chooser")
         return file_chooser
 
     def _on_import_profiles_clicked(self, button: Gtk.Button) -> None:
+        if DEBUG_ENABLED:
+            arg_str = _get_arg_value_reprs(self, button)
+            print(f"DEBUG: Entering {self.__class__.__name__}._on_import_profiles_clicked(args: {arg_str})")
         dialog = self._create_file_chooser(
             title="Import Profiles", action=Gtk.FileChooserAction.OPEN, accept_label="_Open"
         )
         dialog.connect("response", self._on_import_file_chooser_response)
         dialog.show()
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._on_import_profiles_clicked")
 
     def _on_import_file_chooser_response(self, dialog: Gtk.FileChooserNative, response_id: int) -> None:
+        if DEBUG_ENABLED:
+            arg_str = _get_arg_value_reprs(self, dialog, response_id)
+            print(f"DEBUG: Entering {self.__class__.__name__}._on_import_file_chooser_response(args: {arg_str})")
         if response_id == Gtk.ResponseType.ACCEPT:
             gfile = dialog.get_file()
             if gfile:
@@ -140,16 +190,26 @@ class NetworkMapPreferencesWindow(Adw.PreferencesWindow):
                 else:
                      self._show_toast("Failed to get file path for import.")
         dialog.destroy()
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._on_import_file_chooser_response")
 
     def _on_export_profiles_clicked(self, button: Gtk.Button) -> None:
+        if DEBUG_ENABLED:
+            arg_str = _get_arg_value_reprs(self, button)
+            print(f"DEBUG: Entering {self.__class__.__name__}._on_export_profiles_clicked(args: {arg_str})")
         dialog = self._create_file_chooser(
             title="Export All Profiles", action=Gtk.FileChooserAction.SAVE, accept_label="_Save"
         )
         dialog.set_current_name("networkmap_profiles.json")
         dialog.connect("response", self._on_export_file_chooser_response)
         dialog.show()
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._on_export_profiles_clicked")
 
     def _on_export_file_chooser_response(self, dialog: Gtk.FileChooserNative, response_id: int) -> None:
+        if DEBUG_ENABLED:
+            arg_str = _get_arg_value_reprs(self, dialog, response_id)
+            print(f"DEBUG: Entering {self.__class__.__name__}._on_export_file_chooser_response(args: {arg_str})")
         if response_id == Gtk.ResponseType.ACCEPT:
             gfile = dialog.get_file()
             if gfile:
@@ -166,8 +226,12 @@ class NetworkMapPreferencesWindow(Adw.PreferencesWindow):
                 else:
                     self._show_toast("Failed to get file path for export.")
         dialog.destroy()
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._on_export_file_chooser_response")
 
     def _load_and_display_profiles(self) -> None:
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Entering {self.__class__.__name__}._load_and_display_profiles(args: self)")
         while (child := self.profiles_list_box.get_row_at_index(0)) is not None:
             self.profiles_list_box.remove(child)
         try:
@@ -192,8 +256,13 @@ class NetworkMapPreferencesWindow(Adw.PreferencesWindow):
             self._show_toast(f"Error loading profiles: {e}")
         except Exception as e:
             self._show_toast(f"An unexpected error occurred while loading profiles: {e}")
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._load_and_display_profiles")
 
     def _on_add_profile_clicked(self, button: Gtk.Button) -> None:
+        if DEBUG_ENABLED:
+            arg_str = _get_arg_value_reprs(self, button)
+            print(f"DEBUG: Entering {self.__class__.__name__}._on_add_profile_clicked(args: {arg_str})")
         try:
             all_profile_names = [p['name'] for p in self.profile_manager.load_profiles()]
         except ProfileStorageError as e:
@@ -202,8 +271,13 @@ class NetworkMapPreferencesWindow(Adw.PreferencesWindow):
         dialog = ProfileEditorDialog(existing_profile_names=all_profile_names)
         dialog.connect("profile-action", self._handle_profile_dialog_action_add)
         dialog.present(self)
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._on_add_profile_clicked")
 
     def _handle_profile_dialog_action_add(self, dialog: ProfileEditorDialog, action: str, profile_data: Optional[ScanProfile]) -> None:
+        if DEBUG_ENABLED:
+            arg_str = _get_arg_value_reprs(self, dialog, action, profile_data)
+            print(f"DEBUG: Entering {self.__class__.__name__}._handle_profile_dialog_action_add(args: {arg_str})")
         if action == "save" and profile_data:
             try:
                 self.profile_manager.add_profile(profile_data)
@@ -213,8 +287,13 @@ class NetworkMapPreferencesWindow(Adw.PreferencesWindow):
                 self._show_toast(f"Failed to add profile: {e}")
             except Exception as e:
                 self._show_toast(f"An unexpected error occurred while adding profile: {e}")
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._handle_profile_dialog_action_add")
 
     def _on_edit_profile_clicked(self, button: Gtk.Button, profile_name: str) -> None:
+        if DEBUG_ENABLED:
+            arg_str = _get_arg_value_reprs(self, button, profile_name)
+            print(f"DEBUG: Entering {self.__class__.__name__}._on_edit_profile_clicked(args: {arg_str})")
         try:
             current_profiles = self.profile_manager.load_profiles()
             profile_to_edit = next((p for p in current_profiles if p['name'] == profile_name), None)
@@ -230,8 +309,13 @@ class NetworkMapPreferencesWindow(Adw.PreferencesWindow):
                 self._show_toast(f"Error: Profile '{profile_name}' not found for editing.")
         except (ProfileStorageError, Exception) as e:
             self._show_toast(f"Failed to load profile for editing: {e}")
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._on_edit_profile_clicked")
 
     def _handle_profile_dialog_action_edit(self, dialog: ProfileEditorDialog, action: str, profile_data: Optional[ScanProfile], original_profile_name: str) -> None:
+        if DEBUG_ENABLED:
+            arg_str = _get_arg_value_reprs(self, dialog, action, profile_data, original_profile_name)
+            print(f"DEBUG: Entering {self.__class__.__name__}._handle_profile_dialog_action_edit(args: {arg_str})")
         if action == "save" and profile_data:
             try:
                 self.profile_manager.update_profile(original_profile_name, profile_data)
@@ -241,8 +325,13 @@ class NetworkMapPreferencesWindow(Adw.PreferencesWindow):
                 self._show_toast(f"Failed to update profile: {e}")
             except Exception as e:
                 self._show_toast(f"An unexpected error occurred while updating profile: {e}")
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._handle_profile_dialog_action_edit")
 
     def _on_delete_profile_clicked(self, button: Gtk.Button, profile_name: str) -> None:
+        if DEBUG_ENABLED:
+            arg_str = _get_arg_value_reprs(self, button, profile_name)
+            print(f"DEBUG: Entering {self.__class__.__name__}._on_delete_profile_clicked(args: {arg_str})")
         try:
             self.profile_manager.delete_profile(profile_name)
             self._load_and_display_profiles()
@@ -251,16 +340,32 @@ class NetworkMapPreferencesWindow(Adw.PreferencesWindow):
             self._show_toast(f"Failed to delete profile: {e}")
         except Exception as e:
             self._show_toast(f"An unexpected error occurred while deleting profile: {e}")
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._on_delete_profile_clicked")
 
     def _on_font_changed(self, font_button: Gtk.FontButton) -> None:
+        if DEBUG_ENABLED:
+            arg_str = _get_arg_value_reprs(self, font_button)
+            print(f"DEBUG: Entering {self.__class__.__name__}._on_font_changed(args: {arg_str})")
         font_desc = font_button.get_font_desc()
         if font_desc: 
             font_str = font_desc.to_string()
             self.settings.set_string("results-font", font_str)
+            if DEBUG_ENABLED:
+                print(f"DEBUG: {self.__class__.__name__}._on_font_changed - Font set to: {font_str}")
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._on_font_changed")
 
     def _on_theme_changed(self, combo_row: Adw.ComboRow, pspec: GObject.ParamSpec) -> None:
+        if DEBUG_ENABLED:
+            arg_str = _get_arg_value_reprs(self, combo_row, pspec)
+            print(f"DEBUG: Entering {self.__class__.__name__}._on_theme_changed(args: {arg_str})")
         selected_index = combo_row.get_selected()
         if 0 <= selected_index < len(self.THEME_MAP_INDEX_TO_GSETTINGS):
             theme_str = self.THEME_MAP_INDEX_TO_GSETTINGS[selected_index]
             self.settings.set_string("theme", theme_str)
             apply_theme(theme_str)
+            if DEBUG_ENABLED:
+                print(f"DEBUG: {self.__class__.__name__}._on_theme_changed - Theme set to: {theme_str}")
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._on_theme_changed")

--- a/src/profile_command_utils.py
+++ b/src/profile_command_utils.py
@@ -1,5 +1,7 @@
 from typing import TypedDict, Optional, List
 import shlex
+from .config import DEBUG_ENABLED # Import DEBUG_ENABLED
+from .utils import _get_arg_value_reprs # Import the helper
 
 class ProfileOptions(TypedDict, total=False):
     name: Optional[str] # Profile name, not part of Nmap command itself
@@ -35,6 +37,9 @@ def parse_command_to_options(command_str: str) -> ProfileOptions:
     """
     Parses a raw Nmap command string and populates a ProfileOptions dictionary.
     """
+    if DEBUG_ENABLED:
+        # Not using _get_arg_value_reprs here as it's a module-level function
+        print(f"DEBUG: Entering profile_command_utils.parse_command_to_options(command_str={repr(command_str)})")
     options: ProfileOptions = {
         'os_fingerprint': False, 'stealth_scan': False, 'no_ping': False,
         'list_scan': False, 'ping_scan': False, 'tcp_syn_ping': False,
@@ -134,12 +139,17 @@ def parse_command_to_options(command_str: str) -> ProfileOptions:
     if remaining_parts:
         options['additional_args'] = shlex.join(remaining_parts)
 
+    if DEBUG_ENABLED:
+        print(f"DEBUG: Exiting profile_command_utils.parse_command_to_options (options={repr(options)})")
     return options
 
 def build_command_from_options(options: ProfileOptions) -> str:
     """
     Constructs an Nmap command string from a ProfileOptions dictionary.
     """
+    if DEBUG_ENABLED:
+        # Not using _get_arg_value_reprs here
+        print(f"DEBUG: Entering profile_command_utils.build_command_from_options(options={repr(options)})")
     parts: List[str] = []
 
     # Order: Scan Type, Detection, Timing, Ports, Scripts, Other options, Additional Args
@@ -211,7 +221,10 @@ def build_command_from_options(options: ProfileOptions) -> str:
         # shlex.split additional_args in case it contains multiple space-separated arguments
         parts.extend(shlex.split(options['additional_args']))
 
-    return shlex.join(parts)
+    result_command = shlex.join(parts)
+    if DEBUG_ENABLED:
+        print(f"DEBUG: Exiting profile_command_utils.build_command_from_options (command='{result_command}')")
+    return result_command
 
 # Example Usage & Basic Tests (can be expanded)
 if __name__ == '__main__':

--- a/src/profile_editor_dialog.py
+++ b/src/profile_editor_dialog.py
@@ -5,6 +5,7 @@ from typing import Optional, List, Dict, Any
 from .nmap_validator import NmapCommandValidator
 from .profile_command_utils import parse_command_to_options, build_command_from_options, ProfileOptions
 from .config import DEBUG_ENABLED
+from .utils import _get_arg_value_reprs # Import the helper
 
 class ProfileEditorDialog(Adw.Dialog):
     __gtype_name__ = "NetworkMapProfileEditorDialog"
@@ -16,6 +17,11 @@ class ProfileEditorDialog(Adw.Dialog):
     def __init__(self,
                  profile_to_edit: Optional[Dict[str, Any]] = None,
                  existing_profile_names: Optional[List[str]] = None):
+        if DEBUG_ENABLED:
+            # repr(profile_to_edit) could be large if command is long
+            profile_name_for_log = profile_to_edit['name'] if profile_to_edit else "None"
+            arg_str = _get_arg_value_reprs(self, f"profile_to_edit_name={profile_name_for_log}", existing_profile_names=existing_profile_names)
+            print(f"DEBUG: Entering {self.__class__.__name__}.__init__(args: {arg_str})")
 
         super().__init__()
 
@@ -178,9 +184,13 @@ class ProfileEditorDialog(Adw.Dialog):
         self.set_default_widget(save_button)
         self.set_can_close(False)
         self.set_size_request(400, -1)
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}.__init__")
 
     def do_response(self, response_id: str):
         if DEBUG_ENABLED:
+            print(f"DEBUG: Entering {self.__class__.__name__}.do_response(args: self, response_id={repr(response_id)})")
+            # Existing specific log for response_id is good.
             print(f"DEBUG: do_response received: {response_id}", file=sys.stderr)
         if response_id == "apply":
             name = self.profile_name_row.get_text().strip()
@@ -263,18 +273,30 @@ class ProfileEditorDialog(Adw.Dialog):
             if DEBUG_ENABLED:
                 print("DEBUG: cancel - calling self.force_close()", file=sys.stderr)
             self.force_close()
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}.do_response")
 
     def _on_host_discovery_ping_switch_toggled(self, switch_row: Adw.SwitchRow, pspec: Optional[GObject.ParamSpec], entry_row: Adw.EntryRow) -> None:
+        if DEBUG_ENABLED:
+            arg_str = _get_arg_value_reprs(self, switch_row, pspec, entry_row)
+            print(f"DEBUG: Entering {self.__class__.__name__}._on_host_discovery_ping_switch_toggled(args: {arg_str}, active: {switch_row.get_active()})")
         entry_row.set_visible(switch_row.get_active())
         if not switch_row.get_active():
             entry_row.set_text("")
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._on_host_discovery_ping_switch_toggled")
 
     def _show_alert_dialog(self, message: str):
         if DEBUG_ENABLED:
+            # Existing specific log is fine.
             print(f"PROFILE EDITOR INFO (will be AlertDialog): {message}", file=sys.stderr)
+            # Entry log for the method itself
+            print(f"DEBUG: Entering {self.__class__.__name__}._show_alert_dialog(args: self, message={repr(message)})")
         alert_dialog = Adw.AlertDialog(heading="Input Error", body=message)
         alert_dialog.add_response("ok", "OK")
         alert_dialog.set_default_response("ok")
         alert_dialog.set_transient_for(self)
         alert_dialog.set_modal(True)
         alert_dialog.present()
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._show_alert_dialog")

--- a/src/window.py
+++ b/src/window.py
@@ -7,7 +7,7 @@ from gi.repository import Adw, Gtk, GLib, GObject, Gio, Pango
 
 from .nmap_scanner import NmapScanner, NmapArgumentError, NmapScanParseError
 from .nmap_validator import NmapCommandValidator
-from .utils import discover_nse_scripts
+from .utils import discover_nse_scripts, _get_arg_value_reprs
 from .profile_manager import ScanProfile, ProfileManager, PROFILES_SCHEMA_KEY
 from .profile_command_utils import parse_command_to_options, ProfileOptions
 from .config import DEBUG_ENABLED
@@ -38,6 +38,8 @@ class NetworkMapWindow(Adw.ApplicationWindow):
 
     def __init__(self, **kwargs) -> None:
         """Initializes the NetworkMapWindow."""
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Entering {self.__class__.__name__}.__init__(args: {_get_arg_value_reprs(**kwargs)})")
         super().__init__(**kwargs)
 
         self.nmap_scanner: NmapScanner = NmapScanner()
@@ -58,20 +60,29 @@ class NetworkMapWindow(Adw.ApplicationWindow):
         
         self._initialize_ui_elements()
         GLib.idle_add(self._apply_font_preference)
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}.__init__")
 
     def _show_toast(self, message: str):
+        # This method already has a DEBUG_ENABLED check for its print, so not adding entry/exit.
         if DEBUG_ENABLED:
             print(f"MAIN WINDOW TOAST: {message}", file=sys.stderr)
         self.toast_overlay.add_toast(Adw.Toast.new(message))
 
     def _connect_settings_signals(self) -> None:
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Entering {self.__class__.__name__}._connect_settings_signals(args: self)")
         self.settings.connect("changed::results-font", lambda s, k: self._apply_font_preference())
         self.settings.connect("changed::default-nmap-arguments", self._update_nmap_command_preview)
         self.settings.connect("changed::dns-servers", self._update_nmap_command_preview)
         self.settings.connect(f"changed::{PROFILES_SCHEMA_KEY}", lambda s, k: self._populate_profile_combo())
         self.settings.connect(f"changed::{self.TARGET_HISTORY_SCHEMA_KEY}", self._on_target_history_changed)
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._connect_settings_signals")
 
     def _connect_ui_element_signals(self) -> None:
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Entering {self.__class__.__name__}._connect_ui_element_signals(args: self)")
         self.target_entry_row.connect("apply", self._on_scan_button_clicked)
         self.start_scan_button.connect("clicked", self._on_start_scan_button_clicked)
         self.profile_combo_row.connect("notify::selected", self._on_profile_selected)
@@ -86,19 +97,32 @@ class NetworkMapWindow(Adw.ApplicationWindow):
         self.port_spec_entry_row.connect("notify::text", self._on_ports_entry_changed)
         self.nse_script_combo_row.connect("notify::selected", self._on_nse_script_selected) 
         self.timing_template_combo_row.connect("notify::selected", self._on_timing_template_selected)
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._connect_ui_element_signals")
 
     def _on_simple_scan_param_changed(self, widget: Gtk.Widget, pspec: Optional[GObject.ParamSpec] = None) -> None:
+        if DEBUG_ENABLED:
+            arg_str = _get_arg_value_reprs(self, widget, pspec)
+            print(f"DEBUG: Entering {self.__class__.__name__}._on_simple_scan_param_changed(args: {arg_str})")
         self._update_nmap_command_preview()
         self._update_ui_state("ready")
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._on_simple_scan_param_changed")
 
     def _initialize_ui_elements(self) -> None:
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Entering {self.__class__.__name__}._initialize_ui_elements(args: self)")
         self._populate_timing_template_combo()
         self._populate_profile_combo()
         self._populate_nse_script_combo()
         self._update_nmap_command_preview()
         self._update_ui_state("ready")
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._initialize_ui_elements")
 
     def _are_inputs_valid_for_scan(self) -> bool:
+        # This is a utility method, extensive entry/exit logging might be too verbose.
+        # Existing logic seems fine.
         target_text = self.target_entry_row.get_text().strip()
         if not target_text or any(char in target_text for char in [";", "|", "&", "$", "`", "(", ")", "<", ">", "\n", "\r"]):
             return False
@@ -111,6 +135,9 @@ class NetworkMapWindow(Adw.ApplicationWindow):
         return additional_args_are_valid and ports_are_valid
 
     def _on_additional_args_entry_changed(self, entry_row: Adw.EntryRow, pspec: Optional[GObject.ParamSpec] = None) -> None:
+        if DEBUG_ENABLED:
+            arg_str = _get_arg_value_reprs(self, entry_row, pspec)
+            print(f"DEBUG: Entering {self.__class__.__name__}._on_additional_args_entry_changed(args: {arg_str})")
         args_text = entry_row.get_text().strip()
         is_valid, _ = self.validator.validate_arguments(args_text)
         if not is_valid and args_text:
@@ -120,8 +147,13 @@ class NetworkMapWindow(Adw.ApplicationWindow):
             if "error" in self.arguments_entry_row.get_css_classes():
                 self.arguments_entry_row.remove_css_class("error")
         self._update_ui_state("ready")
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._on_additional_args_entry_changed (is_valid: {is_valid})")
 
     def _on_target_entry_changed(self, entry_row: Adw.EntryRow, pspec: Optional[GObject.ParamSpec] = None) -> None:
+        if DEBUG_ENABLED:
+            arg_str = _get_arg_value_reprs(self, entry_row, pspec)
+            print(f"DEBUG: Entering {self.__class__.__name__}._on_target_entry_changed(args: {arg_str})")
         target_text = entry_row.get_text().strip()
         is_valid = True
         if target_text and any(char in target_text for char in [";", "|", "&", "$", "`", "(", ")", "<", ">", "\n", "\r"]):
@@ -133,8 +165,13 @@ class NetworkMapWindow(Adw.ApplicationWindow):
             if "error" in self.target_entry_row.get_css_classes():
                 self.target_entry_row.remove_css_class("error")
         self._update_ui_state("ready")
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._on_target_entry_changed (is_valid: {is_valid})")
 
     def _on_ports_entry_changed(self, entry_row: Adw.EntryRow, pspec: Optional[GObject.ParamSpec] = None) -> None:
+        if DEBUG_ENABLED:
+            arg_str = _get_arg_value_reprs(self, entry_row, pspec)
+            print(f"DEBUG: Entering {self.__class__.__name__}._on_ports_entry_changed(args: {arg_str})")
         ports_text = entry_row.get_text().strip()
         is_valid = True
         if ports_text:
@@ -148,8 +185,12 @@ class NetworkMapWindow(Adw.ApplicationWindow):
             if "error" in self.port_spec_entry_row.get_css_classes():
                 self.port_spec_entry_row.remove_css_class("error")
         self._update_ui_state("ready")
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._on_ports_entry_changed (is_valid: {is_valid})")
 
     def _populate_profile_combo(self) -> None:
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Entering {self.__class__.__name__}._populate_profile_combo(args: self)")
         profiles = self.profile_manager.load_profiles()
         profile_names: List[str] = ["Manual Configuration"] + [p['name'] for p in profiles]
         string_list_model = Gtk.StringList.new(profile_names)
@@ -158,9 +199,15 @@ class NetworkMapWindow(Adw.ApplicationWindow):
             self.profile_combo_row.set_selected(0)
         else:
             print("Warning: Profile combo box is empty after population.", file=sys.stderr)
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._populate_profile_combo (profile_names: {profile_names})")
 
     def _on_profile_selected(self, combo_row: Adw.ComboRow, pspec: GObject.ParamSpec) -> None:
-        if DEBUG_ENABLED: print(f"DEBUG_PROFILE_TRACE: _on_profile_selected - Handler ENTERED.")
+        if DEBUG_ENABLED:
+            arg_str = _get_arg_value_reprs(self, combo_row, pspec) # pspec might be None
+            print(f"DEBUG: Entering {self.__class__.__name__}._on_profile_selected(args: {arg_str})")
+            # Existing DEBUG_PROFILE_TRACE is more detailed, so keeping it.
+            print(f"DEBUG_PROFILE_TRACE: _on_profile_selected - Handler ENTERED.")
 
         selected_idx = combo_row.get_selected()
         model = combo_row.get_model()
@@ -233,17 +280,25 @@ class NetworkMapWindow(Adw.ApplicationWindow):
                     self.profile_combo_row.set_selected(0)
                 else:
                      self._apply_scan_profile(None)
-        if DEBUG_ENABLED: print(f"DEBUG_PROFILE_TRACE: _on_profile_selected - Handler EXITED.")
+        if DEBUG_ENABLED:
+            print(f"DEBUG_PROFILE_TRACE: _on_profile_selected - Handler EXITED.")
+            print(f"DEBUG: Exiting {self.__class__.__name__}._on_profile_selected")
 
     def _populate_timing_template_combo(self) -> None:
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Entering {self.__class__.__name__}._populate_timing_template_combo(args: self)")
         self.timing_options = {
             "Default (T3)": None, "Paranoid (T0)": "-T0", "Sneaky (T1)": "-T1",
             "Polite (T2)": "-T2", "Aggressive (T4)": "-T4", "Insane (T5)": "-T5",
         }
         self.timing_template_combo_row.set_model(Gtk.StringList.new(list(self.timing_options.keys())))
         self.timing_template_combo_row.set_selected(0) 
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._populate_timing_template_combo")
 
     def _get_current_scan_parameters(self) -> Dict[str, Any]:
+        # Utility method, verbose logging might be too much.
+        # The caller _initiate_scan_procedure already logs the returned dict.
         return {
             "target": self.target_entry_row.get_text().strip(),
             "do_os_fingerprint": self.os_fingerprint_switch.get_active(),
@@ -256,6 +311,9 @@ class NetworkMapWindow(Adw.ApplicationWindow):
         }
 
     def _update_nmap_command_preview(self, *args) -> None:
+        if DEBUG_ENABLED:
+            arg_str = _get_arg_value_reprs(self, *args)
+            print(f"DEBUG: Entering {self.__class__.__name__}._update_nmap_command_preview(args: {arg_str})")
         scan_params = self._get_current_scan_parameters()
         target_text = scan_params["target"]
         default_args_from_settings = self.settings.get_string("default-nmap-arguments")
@@ -278,8 +336,12 @@ class NetworkMapWindow(Adw.ApplicationWindow):
             return
         full_command = f"nmap {args_string} {target_text if target_text else '<target_host>'}"
         self.nmap_command_preview_row.set_text(full_command)
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._update_nmap_command_preview")
 
     def _apply_font_preference(self) -> None:
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Entering {self.__class__.__name__}._apply_font_preference(args: self)")
         font_str = self.settings.get_string("results-font")
         css_data = b""
         if font_str:
@@ -310,8 +372,12 @@ class NetworkMapWindow(Adw.ApplicationWindow):
                     style_context.remove_provider(self.font_css_provider)
                     style_context.add_provider(self.font_css_provider, Gtk.STYLE_PROVIDER_PRIORITY_USER)
             child = child.get_next_sibling()
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._apply_font_preference (font_str: {font_str})")
 
     def _populate_nse_script_combo(self) -> None:
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Entering {self.__class__.__name__}._populate_nse_script_combo(args: self)")
         discovered_scripts = discover_nse_scripts()
         combo_items: List[str] = ["None"] + discovered_scripts
         string_list_model = Gtk.StringList.new(combo_items)
@@ -325,9 +391,14 @@ class NetworkMapWindow(Adw.ApplicationWindow):
             self.nse_script_combo_row.set_selected(0)
         else:
             print("Warning: NSE script combo box is empty after population.", file=sys.stderr)
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._populate_nse_script_combo (Loaded {len(combo_items) -1} scripts)")
 
 
     def _on_nse_script_selected(self, combo_row: Adw.ComboRow, pspec: GObject.ParamSpec) -> None:
+        if DEBUG_ENABLED:
+            arg_str = _get_arg_value_reprs(self, combo_row, pspec)
+            print(f"DEBUG: Entering {self.__class__.__name__}._on_nse_script_selected(args: {arg_str})")
         selected_item = combo_row.get_selected_item()
         if isinstance(selected_item, Gtk.StringObject):
             selected_value = selected_item.get_string()
@@ -340,8 +411,13 @@ class NetworkMapWindow(Adw.ApplicationWindow):
                 print(f"Debug: Unexpected item type in NSE script combo: {type(selected_item)}", file=sys.stderr)
         self._update_nmap_command_preview()
         self._update_ui_state("ready")
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._on_nse_script_selected (selected_nse_script: {self.selected_nse_script})")
 
     def _on_timing_template_selected(self, combo_row: Adw.ComboRow, pspec: GObject.ParamSpec) -> None:
+        if DEBUG_ENABLED:
+            arg_str = _get_arg_value_reprs(self, combo_row, pspec)
+            print(f"DEBUG: Entering {self.__class__.__name__}._on_timing_template_selected(args: {arg_str})")
         selected_idx = combo_row.get_selected()
         model = combo_row.get_model()
         if isinstance(model, Gtk.StringList) and selected_idx >= 0:
@@ -351,8 +427,13 @@ class NetworkMapWindow(Adw.ApplicationWindow):
             self.selected_timing_template = None
         self._update_nmap_command_preview()
         self._update_ui_state("ready")
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._on_timing_template_selected (selected_timing_template: {self.selected_timing_template})")
 
     def _update_ui_state(self, state: str, message: Optional[str] = None) -> None:
+        if DEBUG_ENABLED:
+            arg_str = _get_arg_value_reprs(self, state, message=message)
+            print(f"DEBUG: Entering {self.__class__.__name__}._update_ui_state(args: {arg_str})")
         is_scanning = (state == "scanning")
         self.spinner.set_visible(is_scanning)
         base_sensitive = not is_scanning
@@ -392,6 +473,10 @@ class NetworkMapWindow(Adw.ApplicationWindow):
 
     def _apply_scan_profile(self, profile: Optional[ScanProfile]) -> None:
         """Applies settings from a scan profile to the UI using parsed command options."""
+        if DEBUG_ENABLED:
+            # repr(profile) might be too long if command is long, just log name or if it exists
+            profile_repr = f"Profile(name={profile['name']})" if profile else "None"
+            print(f"DEBUG: Entering {self.__class__.__name__}._apply_scan_profile(args: self, profile: {profile_repr})")
 
         if profile:
             command_str = profile.get('command', '')
@@ -489,22 +574,39 @@ class NetworkMapWindow(Adw.ApplicationWindow):
             if "error" in self.arguments_entry_row.get_css_classes(): self.arguments_entry_row.remove_css_class("error")
         self._update_nmap_command_preview()
         self._update_ui_state("ready")
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._apply_scan_profile")
 
     def _add_target_to_history(self, target: str) -> None:
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Entering {self.__class__.__name__}._add_target_to_history(args: self, target: {repr(target)})")
         clean_target = target.strip()
-        if not clean_target: return
+        if not clean_target:
+            if DEBUG_ENABLED:
+                print(f"DEBUG: Exiting {self.__class__.__name__}._add_target_to_history (empty target)")
+            return
         if clean_target in self.target_history_list:
             self.target_history_list.remove(clean_target)
         self.target_history_list.insert(0, clean_target)
         self.target_history_list = self.target_history_list[:self.MAX_HISTORY_SIZE]
         self.settings.set_strv(self.TARGET_HISTORY_SCHEMA_KEY, self.target_history_list)
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._add_target_to_history (history: {self.target_history_list})")
 
     def _on_target_history_changed(self, settings_obj: Gio.Settings, key_name: str) -> None:
+        if DEBUG_ENABLED:
+            arg_str = _get_arg_value_reprs(self, settings_obj, key_name)
+            print(f"DEBUG: Entering {self.__class__.__name__}._on_target_history_changed(args: {arg_str})")
         self.target_history_list = list(self.settings.get_strv(key_name))
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._on_target_history_changed (new history: {self.target_history_list})")
 
     def _initiate_scan_procedure(self) -> None:
         if DEBUG_ENABLED:
+            # This existing UI Action log is good and specific
             print(f"DEBUG: UI Action: Scan initiated by user for target: {self.target_entry_row.get_text().strip()}")
+            # Entry log for the method itself
+            print(f"DEBUG: Entering {self.__class__.__name__}._initiate_scan_procedure(args: self)")
         scan_params = self._get_current_scan_parameters()
         if DEBUG_ENABLED:
             print(f"DEBUG: NetworkMapWindow._initiate_scan_procedure - Scan parameters for NmapScanner: {scan_params}")
@@ -529,17 +631,38 @@ class NetworkMapWindow(Adw.ApplicationWindow):
         scan_thread = threading.Thread(target=self._run_scan_worker, kwargs=worker_kwargs)
         scan_thread.daemon = True
         scan_thread.start()
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._initiate_scan_procedure (scan thread started)")
 
     def _on_scan_button_clicked(self, entry: Adw.EntryRow) -> None:
+        if DEBUG_ENABLED:
+            arg_str = _get_arg_value_reprs(self, entry)
+            print(f"DEBUG: Entering {self.__class__.__name__}._on_scan_button_clicked(args: {arg_str})")
         self._initiate_scan_procedure()
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._on_scan_button_clicked")
 
     def _on_start_scan_button_clicked(self, button: Gtk.Button) -> None:
+        if DEBUG_ENABLED:
+            arg_str = _get_arg_value_reprs(self, button)
+            print(f"DEBUG: Entering {self.__class__.__name__}._on_start_scan_button_clicked(args: {arg_str})")
         self._initiate_scan_procedure()
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._on_start_scan_button_clicked")
 
     def _run_scan_worker(self, target: str, do_os_fingerprint: bool, additional_args_str: str, 
                          nse_script: Optional[str], stealth_scan: bool, port_spec_str: Optional[str], 
                          timing_template_val: Optional[str], do_no_ping_val: bool) -> None:
-        if DEBUG_ENABLED: print(f"DEBUG_PROFILE_TRACE: _run_scan_worker - Received parameters: target='{target}', os={do_os_fingerprint}, additional_args='{additional_args_str}', nse='{nse_script}', stealth={stealth_scan}, ports='{port_spec_str}', timing='{timing_template_val}', no_ping={do_no_ping_val}")
+        if DEBUG_ENABLED:
+            # This existing DEBUG_PROFILE_TRACE is comprehensive for parameters.
+            print(f"DEBUG_PROFILE_TRACE: _run_scan_worker - Received parameters: target='{target}', os={do_os_fingerprint}, additional_args='{additional_args_str}', nse='{nse_script}', stealth={stealth_scan}, ports='{port_spec_str}', timing='{timing_template_val}', no_ping={do_no_ping_val}")
+            # Entry log for the method itself
+            arg_str = _get_arg_value_reprs(self, target=target, do_os_fingerprint=do_os_fingerprint, # etc.
+                                         additional_args_str=additional_args_str, nse_script=nse_script,
+                                         stealth_scan=stealth_scan, port_spec_str=port_spec_str,
+                                         timing_template_val=timing_template_val, do_no_ping_val=do_no_ping_val)
+            print(f"DEBUG: Entering {self.__class__.__name__}._run_scan_worker(args: {arg_str})")
+
         scan_result: Dict[str, Any] = {
             "hosts_data": None, "error_type": None, "error_message": None, "scan_message": None
         }
@@ -565,8 +688,12 @@ class NetworkMapWindow(Adw.ApplicationWindow):
             import traceback
             print(traceback.format_exc(), file=sys.stderr)
         GLib.idle_add(self._process_scan_completion, scan_result)
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._run_scan_worker (scan_result queued for main thread: {repr(scan_result)[:200]}...)")
 
     def _process_scan_completion(self, scan_result: Dict[str, Any]) -> None:
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Entering {self.__class__.__name__}._process_scan_completion(scan_result: {repr(scan_result)[:200]}...)")
         hosts_data = scan_result["hosts_data"]
         error_type = scan_result["error_type"]
         error_message = scan_result["error_message"]
@@ -603,16 +730,26 @@ class NetworkMapWindow(Adw.ApplicationWindow):
             self._show_toast("Scan complete: No data.")
             current_ui_state = "no_data"
         self._update_ui_state(current_ui_state, status_message_override)
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._process_scan_completion")
 
     def _clear_results_ui(self) -> None:
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Entering {self.__class__.__name__}._clear_results_ui(args: self)")
         child = self.results_listbox.get_first_child()
         while child:
             self.results_listbox.remove(child)
             child = self.results_listbox.get_first_child()
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._clear_results_ui")
 
     def _populate_results_listbox(self, hosts_data: List[Dict[str, Any]]) -> None:
         if DEBUG_ENABLED:
+            # This existing log is good.
             print(f"DEBUG: NetworkMapWindow._populate_results_listbox - Populating results for {len(hosts_data)} hosts.")
+            # Entry log for the method itself
+            arg_str = _get_arg_value_reprs(self, f"len(hosts_data)={len(hosts_data)}")
+            print(f"DEBUG: Entering {self.__class__.__name__}._populate_results_listbox(args: {arg_str})")
         for host_data in hosts_data:
             row = HostInfoExpanderRow(host_data=host_data, raw_details_text=host_data.get("raw_details_text", ""))
             if hasattr(self, 'font_css_provider'): 
@@ -625,23 +762,34 @@ class NetworkMapWindow(Adw.ApplicationWindow):
             first_row = self.results_listbox.get_row_at_index(0)
             if isinstance(first_row, HostInfoExpanderRow):
                 first_row.set_expanded(True)
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._populate_results_listbox")
 
     def _display_scan_error(self, error_type: str, error_message: str) -> None:
+        if DEBUG_ENABLED:
+            arg_str = _get_arg_value_reprs(self, error_type, error_message)
+            print(f"DEBUG: Entering {self.__class__.__name__}._display_scan_error(args: {arg_str})")
         self._clear_results_ui()
         friendly_message = f"Scan Error ({error_type}): {error_message}" if error_type != "ScanMessage" else error_message
         self.status_page.set_property("description", friendly_message)
         if DEBUG_ENABLED:
+            # This existing log is good.
             print(f"Scan Error Displayed: Type={error_type}, Message={error_message}", file=sys.stderr)
+            print(f"DEBUG: Exiting {self.__class__.__name__}._display_scan_error")
 
 class HostInfoExpanderRow(Adw.ExpanderRow):
     __gtype_name__ = "HostInfoExpanderRow"
 
     def __init__(self, host_data: Dict[str, Any], raw_details_text: str, **kwargs) -> None:
+        if DEBUG_ENABLED:
+            # repr(host_data) might be too verbose, log keys or specific items if needed
+            arg_str = _get_arg_value_reprs(self, f"host_id={host_data.get('id', 'N/A')}", raw_details_text_len=len(raw_details_text), **kwargs)
+            print(f"DEBUG: Entering {self.__class__.__name__}.__init__(args: {arg_str})")
         super().__init__(**kwargs)
         self.raw_details_text = raw_details_text
         self.set_title(host_data.get("hostname") or host_data.get("id", "Unknown Host"))
         self.set_subtitle(f"State: {host_data.get('state', 'N/A')}")
-        self.set_icon_name("computer-symbolic") 
+        self.set_icon_name("computer-symbolic")
         self._text_view = Gtk.TextView(
             editable=False, cursor_visible=False, wrap_mode=Gtk.WrapMode.WORD_CHAR,
             vexpand=True, hexpand=True )
@@ -657,8 +805,13 @@ class HostInfoExpanderRow(Adw.ExpanderRow):
         frame.set_child(self._text_view)
         self.add_row(frame)
         self.connect("notify::expanded", self._on_expanded_changed)
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}.__init__")
 
     def _on_expanded_changed(self, expander_row: Adw.ExpanderRow, pspec: GObject.ParamSpec) -> None:
+        if DEBUG_ENABLED:
+            arg_str = _get_arg_value_reprs(self, expander_row, pspec)
+            print(f"DEBUG: Entering {self.__class__.__name__}._on_expanded_changed(args: {arg_str}, expanded: {expander_row.get_expanded()})")
         buffer = self._text_view.get_buffer()
         if expander_row.get_expanded():
             buffer.set_text("") 
@@ -671,6 +824,9 @@ class HostInfoExpanderRow(Adw.ExpanderRow):
                 buffer.set_text(plain_text_fallback)
         else:
             buffer.set_text("") 
+        if DEBUG_ENABLED:
+            print(f"DEBUG: Exiting {self.__class__.__name__}._on_expanded_changed")
 
     def get_text_view(self) -> Optional[Gtk.TextView]:
+        # Simple getter, may not need verbose logging unless issues arise.
         return self._text_view


### PR DESCRIPTION
This commit introduces comprehensive debug logging throughout the application to aid in troubleshooting and understanding the execution flow when the `--debug` command-line flag is active.

Key changes include:

1.  **Conditional INFO/DEBUG Messages:**
    - Ensured that initial INFO/DEBUG messages related to Adwaita and GResource loading (originating from `src/networkmap.in`) are now conditional on `config.DEBUG_ENABLED`.

2.  **Extensive Entry/Exit Logging:**
    - Added "Entering" and "Exiting" debug log messages to most functions and methods across all major Python modules in the `src` directory.
    - These logs typically include the function/method name and a representation of its arguments, using a new helper `utils._get_arg_value_reprs` for consistent formatting.

3.  **Module-Specific Logging Details:**
    - **Core Flow (`main.py`, `config.py`, `nmap_scanner.py`):** - Logged command-line arguments, configuration settings, Nmap command construction, execution details (including the exact command run), privilege escalation decisions, and parsing of scan results.
    - **UI Interactions (`window.py`, `preferences_window.py`, `profile_editor_dialog.py`, `nse_script_selection_dialog.py`):**
        - Logged UI event handlers, dialog interactions, parameters passed during UI actions, and manipulation of UI elements.
        - Detailed logging for scan initiation, profile management UI, and preference changes.
    - **Utilities and Other Modules (`utils.py`, `nmap_validator.py`, `profile_command_utils.py`, `profile_manager.py`):** - Logged parameters and return values for utility functions, validation decisions, profile command parsing/reconstruction, and profile loading/saving actions.

4.  **Helper for Argument Logging:**
    - Introduced `_get_arg_value_reprs` in `src/utils.py` to standardize the logging of function/method arguments.

This enhanced logging aims to provide a deep level of insight into the application's runtime behavior when debugging.