### PR TITLE
Fix: Correct developer tag structure in metainfo.xml.in

### DIFF
--- a/data/com.github.mclellac.NetworkMap.metainfo.xml.in
+++ b/data/com.github.mclellac.NetworkMap.metainfo.xml.in
@@ -10,7 +10,6 @@
     <p>No description</p>
   </description>
 
-  <developer id="tld.vendor">
   <developer_name>mclellac</developer_name>
 
   <!-- Requered: Should be a link to the upstream homepage for the component -->


### PR DESCRIPTION
The previous commit introduced an XML validation error in the `data/com.github.mclellac.NetworkMap.metainfo.xml.in` file due to an incorrect nesting of the `<developer_name>` tag. The build process failed with `msgfmt` reporting an "Opening and ending tag mismatch: developer line 13 and component".

This commit corrects the structure by removing the problematic `<developer id="tld.vendor">` tag and its nested content, and places `<developer_name>mclellac</developer_name>` as a direct child of the main `<component>` tag, conforming to AppStream metadata specifications. This should resolve the build failure.