### PR TITLE
chore: Add more specific debug logging for NetworkMapWindow instantia…

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -76,7 +76,9 @@ class NetworkMapApplication(Adw.Application):
             print(f"DEBUG: Entering NetworkMapApplication.do_activate(args: self)")
         win: Optional[NetworkMapWindow] = self.get_active_window()
         if not win:
+            if config.DEBUG_ENABLED: print(f"DEBUG: NetworkMapApplication.do_activate - About to create NetworkMapWindow")
             win = NetworkMapWindow(application=self)
+            if config.DEBUG_ENABLED: print(f"DEBUG: NetworkMapApplication.do_activate - NetworkMapWindow created. Type: {type(win)}")
         win.present()
         if config.DEBUG_ENABLED:
             print(f"DEBUG: Exiting NetworkMapApplication.do_activate")


### PR DESCRIPTION
…tion

Added debug statements in `NetworkMapApplication.do_activate` immediately before and after the instantiation of `NetworkMapWindow`.

This is to help diagnose why logs from `NetworkMapWindow.__init__` are not appearing in debug output, by confirming if the instantiation line is reached and completes.